### PR TITLE
feat(api): add comprehensive input validation middleware (Issue #309)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-07T19:35:41.595Z for PR creation at branch issue-292-bd649a0c8fa3 for issue https://github.com/xlabtg/TONAIAgent/issues/292
+# Updated: 2026-04-10T01:13:28.965Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-07T19:35:41.595Z for PR creation at branch issue-292-bd649a0c8fa3 for issue https://github.com/xlabtg/TONAIAgent/issues/292
-# Updated: 2026-04-10T01:13:28.965Z

--- a/core/agents/control/types.ts
+++ b/core/agents/control/types.ts
@@ -91,6 +91,10 @@ export interface AgentControlResponseBody<T = unknown> {
   data?: T;
   error?: string;
   code?: AgentControlErrorCode;
+  /** Seconds until the client may retry (used with RATE_LIMIT_EXCEEDED) */
+  retryAfter?: number;
+  /** Field-level validation issues (used with VALIDATION_ERROR) */
+  details?: Array<{ path: string; message: string }>;
 }
 
 /** Response for lifecycle action endpoints (start/stop/restart) */
@@ -165,7 +169,10 @@ export type AgentControlErrorCode =
   | 'AGENT_ALREADY_STOPPED'
   | 'AGENT_IN_ERROR_STATE'
   | 'INVALID_AGENT_ID'
-  | 'OPERATION_FAILED';
+  | 'OPERATION_FAILED'
+  | 'RATE_LIMIT_EXCEEDED'
+  | 'VALIDATION_ERROR'
+  | 'UNSUPPORTED_MEDIA_TYPE';
 
 /** Structured error for agent control operations */
 export class AgentControlError extends Error {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@tonaiagent/core",
       "version": "2.43.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
       "devDependencies": {
         "@types/node": "^25.5.2",
         "@typescript-eslint/eslint-plugin": "^8.58.1",
@@ -3748,6 +3751,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -632,5 +632,8 @@
     "typescript": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
   }
 }

--- a/services/api/index.ts
+++ b/services/api/index.ts
@@ -1,4 +1,10 @@
 /** @mvp MVP service — agent control REST API gateway */
 // API Service — main API gateway and agent control interface
 // Agent control API implementations are in core/agents/control/
-export * from '../../core/agents/control';
+export * from '../../core/agents/control/index.js';
+
+// Middleware — validation, rate limiting, security headers
+export * from './middleware/index.js';
+
+// Schemas — Zod schemas for all request bodies
+export * from './schemas/index.js';

--- a/services/api/middleware/index.ts
+++ b/services/api/middleware/index.ts
@@ -1,0 +1,9 @@
+/**
+ * TONAIAgent - API Middleware
+ *
+ * Re-exports all API middleware for convenient single-import usage.
+ */
+
+export * from './validate.js';
+export * from './rate-limit.js';
+export * from './security-headers.js';

--- a/services/api/middleware/rate-limit.ts
+++ b/services/api/middleware/rate-limit.ts
@@ -1,0 +1,134 @@
+/**
+ * TONAIAgent - Rate Limiting Middleware
+ *
+ * Framework-agnostic in-memory rate limiter based on a sliding-window
+ * counter.  Mirrors the semantics of `express-rate-limit` but requires
+ * no HTTP framework — it operates directly on IP/user identifiers.
+ *
+ * Implements Issue #309: API input validation
+ */
+
+import type { AgentControlRequest, AgentControlResponse } from '../../../core/agents/control/index.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RateLimitConfig {
+  /** Length of the window in milliseconds */
+  windowMs: number;
+  /** Maximum number of requests allowed within the window */
+  max: number;
+  /** Key extractor — defaults to IP from headers */
+  keyExtractor?: (req: AgentControlRequest) => string;
+}
+
+interface WindowEntry {
+  count: number;
+  resetAt: number;
+}
+
+// ============================================================================
+// RateLimiter
+// ============================================================================
+
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Call `check(req)` on every incoming request.  If the limit has not been
+ * exceeded the method returns `null` (pass-through).  If the limit IS
+ * exceeded it returns a 429 `AgentControlResponse` that should be sent
+ * immediately without further processing.
+ */
+export class RateLimiter {
+  private readonly config: Required<RateLimitConfig>;
+  private readonly windows = new Map<string, WindowEntry>();
+
+  constructor(config: RateLimitConfig) {
+    this.config = {
+      keyExtractor: defaultKeyExtractor,
+      ...config,
+    };
+  }
+
+  /**
+   * Check whether the request is within the rate limit.
+   * Returns `null` if the request is allowed, or a 429 response if blocked.
+   */
+  check(req: AgentControlRequest): AgentControlResponse | null {
+    const key = this.config.keyExtractor(req);
+    const now = Date.now();
+    const entry = this.windows.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      // Start a new window
+      this.windows.set(key, { count: 1, resetAt: now + this.config.windowMs });
+      return null;
+    }
+
+    entry.count++;
+
+    if (entry.count > this.config.max) {
+      const retryAfterSecs = Math.ceil((entry.resetAt - now) / 1000);
+      return {
+        statusCode: 429,
+        body: {
+          success: false,
+          error: 'Too many requests — please retry later',
+          code: 'RATE_LIMIT_EXCEEDED' as const,
+          retryAfter: retryAfterSecs,
+        },
+      };
+    }
+
+    return null;
+  }
+
+  /** Reset the counter for a specific key (useful in tests). */
+  reset(key?: string): void {
+    if (key !== undefined) {
+      this.windows.delete(key);
+    } else {
+      this.windows.clear();
+    }
+  }
+}
+
+// ============================================================================
+// Default Key Extractor
+// ============================================================================
+
+function defaultKeyExtractor(req: AgentControlRequest): string {
+  // Respect standard proxy headers first, then fall back to a placeholder
+  return (
+    req.headers?.['x-forwarded-for']?.split(',')[0]?.trim() ??
+    req.headers?.['x-real-ip'] ??
+    'unknown'
+  );
+}
+
+// ============================================================================
+// Pre-built Rate Limiters
+// ============================================================================
+
+/**
+ * Standard rate limit: 100 requests per 15-minute window.
+ * Suitable for general read endpoints.
+ */
+export function createStandardRateLimit(): RateLimiter {
+  return new RateLimiter({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100,
+  });
+}
+
+/**
+ * Trade/mutation rate limit: 10 requests per 1-minute window.
+ * Suitable for state-mutating endpoints (start/stop/restart).
+ */
+export function createTradeRateLimit(): RateLimiter {
+  return new RateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    max: 10,
+  });
+}

--- a/services/api/middleware/security-headers.ts
+++ b/services/api/middleware/security-headers.ts
@@ -1,0 +1,169 @@
+/**
+ * TONAIAgent - Security Headers Middleware
+ *
+ * Framework-agnostic security-header helpers inspired by Helmet.js.
+ * Returns a plain `Record<string, string>` that callers can merge into
+ * their HTTP response headers.
+ *
+ * Headers applied:
+ *   X-Content-Type-Options: nosniff            — prevent MIME sniffing
+ *   X-Frame-Options: DENY                       — prevent clickjacking
+ *   X-XSS-Protection: 0                         — disable legacy XSS filter (modern browsers ignore it; CSP is the real protection)
+ *   Content-Security-Policy: default-src 'none' — strict CSP for API responses
+ *   Strict-Transport-Security                   — enforce HTTPS (in production)
+ *   Referrer-Policy: no-referrer                — do not leak referrer
+ *   Permissions-Policy                          — disable unused browser features
+ *   Cache-Control: no-store                     — never cache API responses
+ *
+ * Implements Issue #309: API input validation
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SecurityHeadersOptions {
+  /**
+   * Set to `true` in production to emit the Strict-Transport-Security header.
+   * Default: `false` (avoids breaking local HTTP development).
+   */
+  enableHSTS?: boolean;
+  /** HSTS max-age in seconds. Default: 1 year (31 536 000). */
+  hstsMaxAge?: number;
+}
+
+// ============================================================================
+// Header Generation
+// ============================================================================
+
+/**
+ * Generate a set of security response headers.
+ *
+ * @example
+ * ```ts
+ * const headers = getSecurityHeaders({ enableHSTS: process.env.NODE_ENV === 'production' });
+ * // Merge into your HTTP framework's response headers.
+ * ```
+ */
+export function getSecurityHeaders(options: SecurityHeadersOptions = {}): Record<string, string> {
+  const { enableHSTS = false, hstsMaxAge = 31_536_000 } = options;
+
+  const headers: Record<string, string> = {
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    // Modern browsers ignore X-XSS-Protection; keeping it at 0 prevents
+    // the legacy mode from inadvertently blocking legitimate content.
+    'X-XSS-Protection': '0',
+    'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'",
+    'Referrer-Policy': 'no-referrer',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+    // API responses must never be cached to prevent sensitive data exposure
+    'Cache-Control': 'no-store',
+  };
+
+  if (enableHSTS) {
+    headers['Strict-Transport-Security'] = `max-age=${hstsMaxAge}; includeSubDomains`;
+  }
+
+  return headers;
+}
+
+// ============================================================================
+// CSRF helpers
+// ============================================================================
+
+/** HTTP methods that mutate state and therefore require CSRF protection */
+const CSRF_PROTECTED_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * Validate the CSRF token for state-mutating requests.
+ *
+ * The expected token must be provided out-of-band (e.g. via an initial
+ * GET request or a secure cookie) and matched against the `x-csrf-token`
+ * request header.
+ *
+ * Returns `true` when:
+ *   - The request method is safe (GET, HEAD, OPTIONS).
+ *   - The `x-csrf-token` header matches the expected token.
+ *
+ * Returns `false` (invalid) when the header is absent or does not match.
+ */
+export function isCsrfTokenValid(
+  method: string,
+  headers: Record<string, string> | undefined,
+  expectedToken: string,
+): boolean {
+  if (!CSRF_PROTECTED_METHODS.has(method)) return true;
+  const token = headers?.['x-csrf-token'];
+  if (!token || token.length === 0) return false;
+  return timingSafeEqual(token, expectedToken);
+}
+
+// ============================================================================
+// Request size validation
+// ============================================================================
+
+/**
+ * Check whether the declared `Content-Length` exceeds the configured maximum.
+ * Returns `true` when the size is within bounds (or when the header is absent).
+ */
+export function isBodySizeAllowed(
+  headers: Record<string, string> | undefined,
+  maxBytes: number,
+): boolean {
+  const raw = headers?.['content-length'];
+  if (!raw) return true;
+  const bytes = parseInt(raw, 10);
+  if (isNaN(bytes)) return true;
+  return bytes <= maxBytes;
+}
+
+// ============================================================================
+// Request timeout helpers
+// ============================================================================
+
+/**
+ * Wrap an async handler with a timeout.
+ * Rejects with a structured timeout error if the handler takes longer than
+ * `timeoutMs` milliseconds.
+ */
+export async function withTimeout<T>(
+  handler: () => Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new RequestTimeoutError(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    handler().then(
+      result => { clearTimeout(timer); resolve(result); },
+      err    => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
+export class RequestTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Falls back to a simple comparison when strings have different lengths
+ * (length itself is observable, but exposing it here leaks no secret).
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/services/api/middleware/validate.ts
+++ b/services/api/middleware/validate.ts
@@ -1,0 +1,124 @@
+/**
+ * TONAIAgent - Schema Validation Middleware
+ *
+ * Framework-agnostic request body validation using Zod.
+ * Validates incoming request bodies against a given Zod schema and
+ * returns a structured 400 response on failure without exposing the
+ * raw body in error logs.
+ *
+ * Implements Issue #309: API input validation
+ */
+
+import { z } from 'zod';
+import type { AgentControlRequest, AgentControlResponse } from '../../../core/agents/control/index.js';
+
+// ============================================================================
+// Validation Result
+// ============================================================================
+
+export interface ValidationSuccess<T> {
+  ok: true;
+  data: T;
+}
+
+export interface ValidationFailure {
+  ok: false;
+  response: AgentControlResponse;
+}
+
+export type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+// ============================================================================
+// Middleware
+// ============================================================================
+
+/**
+ * Validate the body of an API request against a Zod schema.
+ *
+ * On success, returns `{ ok: true, data }` with the parsed (typed) body.
+ * On failure, returns `{ ok: false, response }` with a 400 error response.
+ * The rejection is logged with the validation errors (but NOT the raw body
+ * to avoid leaking sensitive data).
+ */
+export function validateBody<TSchema extends z.ZodTypeAny>(
+  req: AgentControlRequest,
+  schema: TSchema,
+): ValidationResult<z.infer<TSchema>> {
+  const result = schema.safeParse(req.body);
+
+  if (result.success) {
+    return { ok: true, data: result.data as z.infer<TSchema> };
+  }
+
+  const issues = result.error.issues.map(i => ({
+    path: i.path.join('.'),
+    message: i.message,
+  }));
+
+  return {
+    ok: false,
+    response: {
+      statusCode: 400,
+      body: {
+        success: false,
+        error: 'Request body validation failed',
+        code: 'VALIDATION_ERROR' as const,
+        details: issues,
+      },
+    },
+  };
+}
+
+/**
+ * Validate Content-Type header for POST/PUT/PATCH requests that carry a body.
+ * Returns a 415 response when the header is absent or not JSON.
+ */
+export function validateContentType(req: AgentControlRequest): AgentControlResponse | null {
+  const bodyMethods = new Set(['POST', 'PUT', 'PATCH']);
+  if (!bodyMethods.has(req.method)) return null;
+
+  const contentType = req.headers?.['content-type'] ?? '';
+  if (!contentType.includes('application/json')) {
+    return {
+      statusCode: 415,
+      body: {
+        success: false,
+        error: 'Content-Type must be application/json',
+        code: 'UNSUPPORTED_MEDIA_TYPE' as const,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Sanitize a string to remove characters that could enable XSS attacks.
+ * Strips script/style blocks (including their content), remaining HTML tags,
+ * null bytes, and encodes residual angle brackets.
+ */
+export function sanitizeString(value: string): string {
+  return value
+    .replace(/\0/g, '')                                      // remove null bytes
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')   // strip script/style with content
+    .replace(/<[^>]*>/g, '')                                 // strip remaining HTML tags
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Recursively sanitize all string values in an object.
+ * Safe to call on parsed/validated request bodies.
+ */
+export function sanitizeObject(obj: unknown): unknown {
+  if (typeof obj === 'string') return sanitizeString(obj);
+  if (Array.isArray(obj)) return obj.map(sanitizeObject);
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      result[key] = sanitizeObject(value);
+    }
+    return result;
+  }
+  return obj;
+}

--- a/services/api/schemas/agent.ts
+++ b/services/api/schemas/agent.ts
@@ -1,0 +1,39 @@
+/**
+ * TONAIAgent - Agent API Zod Schemas
+ *
+ * Zod validation schemas for all agent-related API request bodies.
+ * These schemas are used by the validation middleware to enforce
+ * correct input shape, types, and value ranges.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Agent Creation Schema
+// ============================================================================
+
+/** Schema for POST /api/agents — create a new agent */
+export const CreateAgentSchema = z.object({
+  userId: z.string().min(1).max(100),
+  name: z.string().min(1).max(200),
+  strategy: z.enum(['trend', 'arbitrage', 'ai_signal']),
+  budgetTon: z.number().positive().max(1_000_000),
+  riskLevel: z.enum(['low', 'medium', 'high']),
+});
+
+/** Schema for PATCH/PUT /api/agents/:id/configure */
+export const ConfigureAgentSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  strategy: z.enum(['trend', 'arbitrage', 'ai_signal']).optional(),
+  budgetTon: z.number().positive().max(1_000_000).optional(),
+  riskLevel: z.enum(['low', 'medium', 'high']).optional(),
+}).refine(obj => Object.keys(obj).length > 0, {
+  message: 'At least one field must be provided for configuration update',
+});
+
+// ============================================================================
+// Inferred Types
+// ============================================================================
+
+export type CreateAgentInput = z.infer<typeof CreateAgentSchema>;
+export type ConfigureAgentInput = z.infer<typeof ConfigureAgentSchema>;

--- a/services/api/schemas/index.ts
+++ b/services/api/schemas/index.ts
@@ -1,0 +1,7 @@
+/**
+ * TONAIAgent - API Schemas
+ *
+ * Re-exports all Zod schemas for the API layer.
+ */
+
+export * from './agent.js';

--- a/tests/api/validation.test.ts
+++ b/tests/api/validation.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Tests for Issue #309: Comprehensive API Input Validation
+ *
+ * Covers:
+ * - validateBody: success, missing fields, wrong types, out-of-range values
+ * - validateContentType: JSON enforcement, safe-method bypass
+ * - sanitizeString / sanitizeObject: XSS prevention
+ * - RateLimiter: under-limit pass-through, limit enforcement, window reset
+ * - createStandardRateLimit / createTradeRateLimit: factory defaults
+ * - getSecurityHeaders: presence and values of all expected headers
+ * - isCsrfTokenValid: valid token, missing token, method bypass
+ * - isBodySizeAllowed: within limit, over limit, absent header
+ * - withTimeout: completes before timeout, times out
+ * - CreateAgentSchema / ConfigureAgentSchema: valid + invalid inputs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+import {
+  validateBody,
+  validateContentType,
+  sanitizeString,
+  sanitizeObject,
+} from '../../services/api/middleware/validate.js';
+
+import {
+  RateLimiter,
+  createStandardRateLimit,
+  createTradeRateLimit,
+} from '../../services/api/middleware/rate-limit.js';
+
+import {
+  getSecurityHeaders,
+  isCsrfTokenValid,
+  isBodySizeAllowed,
+  withTimeout,
+  RequestTimeoutError,
+} from '../../services/api/middleware/security-headers.js';
+
+import {
+  CreateAgentSchema,
+  ConfigureAgentSchema,
+} from '../../services/api/schemas/agent.js';
+
+import type { AgentControlRequest } from '../../core/agents/control/index.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeReq(overrides: Partial<AgentControlRequest> = {}): AgentControlRequest {
+  return {
+    method: 'GET',
+    path: '/api/agents',
+    headers: { 'content-type': 'application/json' },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// validateBody
+// ============================================================================
+
+describe('validateBody', () => {
+  const schema = z.object({ name: z.string().min(1), value: z.number() });
+
+  it('returns ok=true with parsed data on valid body', () => {
+    const req = makeReq({ body: { name: 'test', value: 42 } });
+    const result = validateBody(req, schema);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.name).toBe('test');
+      expect(result.data.value).toBe(42);
+    }
+  });
+
+  it('returns ok=false with 400 response on missing required field', () => {
+    const req = makeReq({ body: { name: 'test' } });
+    const result = validateBody(req, schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.statusCode).toBe(400);
+      expect(result.response.body.success).toBe(false);
+      expect(result.response.body.error).toMatch(/validation/i);
+    }
+  });
+
+  it('returns ok=false when body is null', () => {
+    const req = makeReq({ body: null });
+    const result = validateBody(req, schema);
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok=false when field type is wrong', () => {
+    const req = makeReq({ body: { name: 'ok', value: 'not-a-number' } });
+    const result = validateBody(req, schema);
+    expect(result.ok).toBe(false);
+  });
+
+  it('includes field path in error details', () => {
+    const req = makeReq({ body: { value: 5 } }); // missing name
+    const result = validateBody(req, schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const details = (result.response.body as Record<string, unknown>).details as Array<{ path: string; message: string }>;
+      expect(details.some(d => d.path === 'name')).toBe(true);
+    }
+  });
+});
+
+// ============================================================================
+// validateContentType
+// ============================================================================
+
+describe('validateContentType', () => {
+  it('returns null for GET requests (no body required)', () => {
+    const req = makeReq({ method: 'GET', headers: {} });
+    expect(validateContentType(req)).toBeNull();
+  });
+
+  it('returns null for POST with application/json', () => {
+    const req = makeReq({ method: 'POST', headers: { 'content-type': 'application/json' } });
+    expect(validateContentType(req)).toBeNull();
+  });
+
+  it('returns null for POST with application/json; charset=utf-8', () => {
+    const req = makeReq({ method: 'POST', headers: { 'content-type': 'application/json; charset=utf-8' } });
+    expect(validateContentType(req)).toBeNull();
+  });
+
+  it('returns 415 for POST with text/plain', () => {
+    const req = makeReq({ method: 'POST', headers: { 'content-type': 'text/plain' } });
+    const res = validateContentType(req);
+    expect(res).not.toBeNull();
+    expect(res?.statusCode).toBe(415);
+    expect(res?.body.success).toBe(false);
+  });
+
+  it('returns 415 for POST with missing content-type header', () => {
+    const req = makeReq({ method: 'POST', headers: {} });
+    const res = validateContentType(req);
+    expect(res?.statusCode).toBe(415);
+  });
+});
+
+// ============================================================================
+// sanitizeString
+// ============================================================================
+
+describe('sanitizeString', () => {
+  it('removes null bytes', () => {
+    expect(sanitizeString('he\0llo')).toBe('hello');
+  });
+
+  it('strips HTML tags', () => {
+    expect(sanitizeString('<script>alert(1)</script>hello')).toBe('hello');
+  });
+
+  it('encodes remaining angle brackets after tag stripping', () => {
+    // "a<b" has no closing >, so the tag is not matched — angle bracket is encoded
+    expect(sanitizeString('a<b')).toBe('a&lt;b');
+  });
+
+  it('does not modify clean strings', () => {
+    expect(sanitizeString('Hello World 123')).toBe('Hello World 123');
+  });
+});
+
+// ============================================================================
+// sanitizeObject
+// ============================================================================
+
+describe('sanitizeObject', () => {
+  it('sanitizes string values in a flat object', () => {
+    const result = sanitizeObject({ name: '<b>Alice</b>', age: 30 }) as Record<string, unknown>;
+    expect(result.name).toBe('Alice');
+    expect(result.age).toBe(30);
+  });
+
+  it('recurses into nested objects', () => {
+    const result = sanitizeObject({ outer: { inner: '<evil>' } }) as Record<string, unknown>;
+    expect((result.outer as Record<string, unknown>).inner).toBe('');
+  });
+
+  it('sanitizes strings inside arrays', () => {
+    const result = sanitizeObject(['<img>', 'safe']) as string[];
+    expect(result[0]).toBe('');
+    expect(result[1]).toBe('safe');
+  });
+
+  it('leaves numbers and booleans unchanged', () => {
+    expect(sanitizeObject(42)).toBe(42);
+    expect(sanitizeObject(true)).toBe(true);
+  });
+});
+
+// ============================================================================
+// RateLimiter
+// ============================================================================
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter({ windowMs: 60_000, max: 3 });
+  });
+
+  const makeIpReq = (ip: string): AgentControlRequest =>
+    makeReq({ headers: { 'x-forwarded-for': ip } });
+
+  it('allows requests below the limit', () => {
+    expect(limiter.check(makeIpReq('1.2.3.4'))).toBeNull();
+    expect(limiter.check(makeIpReq('1.2.3.4'))).toBeNull();
+    expect(limiter.check(makeIpReq('1.2.3.4'))).toBeNull();
+  });
+
+  it('blocks the (max+1)-th request with 429', () => {
+    for (let i = 0; i < 3; i++) limiter.check(makeIpReq('1.2.3.4'));
+    const res = limiter.check(makeIpReq('1.2.3.4'));
+    expect(res?.statusCode).toBe(429);
+    expect(res?.body.success).toBe(false);
+  });
+
+  it('tracks different IPs independently', () => {
+    for (let i = 0; i < 3; i++) limiter.check(makeIpReq('1.1.1.1'));
+    // 1.1.1.1 is now at the limit, but 2.2.2.2 should pass freely
+    expect(limiter.check(makeIpReq('2.2.2.2'))).toBeNull();
+  });
+
+  it('resets the counter on reset(key)', () => {
+    for (let i = 0; i < 3; i++) limiter.check(makeIpReq('1.2.3.4'));
+    limiter.reset('1.2.3.4');
+    expect(limiter.check(makeIpReq('1.2.3.4'))).toBeNull();
+  });
+
+  it('resets all counters on reset()', () => {
+    for (let i = 0; i < 3; i++) limiter.check(makeIpReq('1.2.3.4'));
+    limiter.reset();
+    expect(limiter.check(makeIpReq('1.2.3.4'))).toBeNull();
+  });
+
+  it('uses x-real-ip as fallback key', () => {
+    const req = makeReq({ headers: { 'x-real-ip': '5.6.7.8' } });
+    expect(limiter.check(req)).toBeNull();
+  });
+
+  it('falls back to "unknown" when no IP header present', () => {
+    const req = makeReq({ headers: {} });
+    expect(limiter.check(req)).toBeNull();
+  });
+});
+
+describe('createStandardRateLimit', () => {
+  it('creates a limiter with max 100', () => {
+    const limiter = createStandardRateLimit();
+    // Should allow 100 requests
+    const makeIpReq = (ip: string) => makeReq({ headers: { 'x-forwarded-for': ip } });
+    for (let i = 0; i < 100; i++) expect(limiter.check(makeIpReq('10.0.0.1'))).toBeNull();
+    expect(limiter.check(makeIpReq('10.0.0.1'))?.statusCode).toBe(429);
+  });
+});
+
+describe('createTradeRateLimit', () => {
+  it('creates a limiter with max 10', () => {
+    const limiter = createTradeRateLimit();
+    const makeIpReq = (ip: string) => makeReq({ headers: { 'x-forwarded-for': ip } });
+    for (let i = 0; i < 10; i++) expect(limiter.check(makeIpReq('10.0.0.2'))).toBeNull();
+    expect(limiter.check(makeIpReq('10.0.0.2'))?.statusCode).toBe(429);
+  });
+});
+
+// ============================================================================
+// getSecurityHeaders
+// ============================================================================
+
+describe('getSecurityHeaders', () => {
+  it('includes all required security headers', () => {
+    const headers = getSecurityHeaders();
+    expect(headers['X-Content-Type-Options']).toBe('nosniff');
+    expect(headers['X-Frame-Options']).toBe('DENY');
+    expect(headers['X-XSS-Protection']).toBe('0');
+    expect(headers['Content-Security-Policy']).toContain("default-src 'none'");
+    expect(headers['Referrer-Policy']).toBe('no-referrer');
+    expect(headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('does not include HSTS by default', () => {
+    const headers = getSecurityHeaders();
+    expect(headers['Strict-Transport-Security']).toBeUndefined();
+  });
+
+  it('includes HSTS when enableHSTS=true', () => {
+    const headers = getSecurityHeaders({ enableHSTS: true });
+    expect(headers['Strict-Transport-Security']).toMatch(/max-age=\d+/);
+  });
+
+  it('respects custom hstsMaxAge', () => {
+    const headers = getSecurityHeaders({ enableHSTS: true, hstsMaxAge: 3600 });
+    expect(headers['Strict-Transport-Security']).toContain('max-age=3600');
+  });
+});
+
+// ============================================================================
+// isCsrfTokenValid
+// ============================================================================
+
+describe('isCsrfTokenValid', () => {
+  const token = 'my-secret-csrf-token';
+
+  it('returns true for GET requests (no CSRF needed)', () => {
+    expect(isCsrfTokenValid('GET', {}, token)).toBe(true);
+  });
+
+  it('returns true for HEAD requests', () => {
+    expect(isCsrfTokenValid('HEAD', {}, token)).toBe(true);
+  });
+
+  it('returns true for POST with correct token', () => {
+    expect(isCsrfTokenValid('POST', { 'x-csrf-token': token }, token)).toBe(true);
+  });
+
+  it('returns false for POST with wrong token', () => {
+    expect(isCsrfTokenValid('POST', { 'x-csrf-token': 'wrong' }, token)).toBe(false);
+  });
+
+  it('returns false for POST with missing token', () => {
+    expect(isCsrfTokenValid('POST', {}, token)).toBe(false);
+  });
+
+  it('returns false for PUT with missing token', () => {
+    expect(isCsrfTokenValid('PUT', {}, token)).toBe(false);
+  });
+
+  it('returns false for DELETE with wrong token', () => {
+    expect(isCsrfTokenValid('DELETE', { 'x-csrf-token': token + 'X' }, token)).toBe(false);
+  });
+});
+
+// ============================================================================
+// isBodySizeAllowed
+// ============================================================================
+
+describe('isBodySizeAllowed', () => {
+  const limit = 102_400; // 100 KB
+
+  it('returns true when content-length is below limit', () => {
+    expect(isBodySizeAllowed({ 'content-length': '1024' }, limit)).toBe(true);
+  });
+
+  it('returns true when content-length equals limit', () => {
+    expect(isBodySizeAllowed({ 'content-length': String(limit) }, limit)).toBe(true);
+  });
+
+  it('returns false when content-length exceeds limit', () => {
+    expect(isBodySizeAllowed({ 'content-length': String(limit + 1) }, limit)).toBe(false);
+  });
+
+  it('returns true when content-length header is absent', () => {
+    expect(isBodySizeAllowed({}, limit)).toBe(true);
+  });
+
+  it('returns true when headers are undefined', () => {
+    expect(isBodySizeAllowed(undefined, limit)).toBe(true);
+  });
+
+  it('returns true for non-numeric content-length', () => {
+    expect(isBodySizeAllowed({ 'content-length': 'bogus' }, limit)).toBe(true);
+  });
+});
+
+// ============================================================================
+// withTimeout
+// ============================================================================
+
+describe('withTimeout', () => {
+  it('resolves when handler completes in time', async () => {
+    const result = await withTimeout(() => Promise.resolve(42), 1000);
+    expect(result).toBe(42);
+  });
+
+  it('rejects with RequestTimeoutError when handler exceeds timeout', async () => {
+    const slow = () => new Promise<never>(resolve => setTimeout(resolve, 200));
+    await expect(withTimeout(slow, 50)).rejects.toBeInstanceOf(RequestTimeoutError);
+  });
+
+  it('propagates handler errors', async () => {
+    const broken = () => Promise.reject(new Error('boom'));
+    await expect(withTimeout(broken, 1000)).rejects.toThrow('boom');
+  });
+});
+
+// ============================================================================
+// CreateAgentSchema
+// ============================================================================
+
+describe('CreateAgentSchema', () => {
+  const validPayload = {
+    userId: 'user_123',
+    name: 'My Trend Agent',
+    strategy: 'trend',
+    budgetTon: 500,
+    riskLevel: 'medium',
+  };
+
+  it('accepts a fully valid payload', () => {
+    expect(CreateAgentSchema.safeParse(validPayload).success).toBe(true);
+  });
+
+  it('rejects missing userId', () => {
+    const { userId: _, ...rest } = validPayload;
+    expect(CreateAgentSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects empty userId', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, userId: '' }).success).toBe(false);
+  });
+
+  it('rejects userId longer than 100 characters', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, userId: 'x'.repeat(101) }).success).toBe(false);
+  });
+
+  it('rejects unknown strategy', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, strategy: 'unknown' }).success).toBe(false);
+  });
+
+  it('accepts all valid strategies', () => {
+    for (const strategy of ['trend', 'arbitrage', 'ai_signal']) {
+      expect(CreateAgentSchema.safeParse({ ...validPayload, strategy }).success).toBe(true);
+    }
+  });
+
+  it('rejects negative budgetTon', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, budgetTon: -1 }).success).toBe(false);
+  });
+
+  it('rejects budgetTon exceeding 1_000_000', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, budgetTon: 1_000_001 }).success).toBe(false);
+  });
+
+  it('rejects invalid riskLevel', () => {
+    expect(CreateAgentSchema.safeParse({ ...validPayload, riskLevel: 'extreme' }).success).toBe(false);
+  });
+});
+
+// ============================================================================
+// ConfigureAgentSchema
+// ============================================================================
+
+describe('ConfigureAgentSchema', () => {
+  it('accepts a partial update with just one field', () => {
+    expect(ConfigureAgentSchema.safeParse({ name: 'New Name' }).success).toBe(true);
+  });
+
+  it('accepts a full update', () => {
+    expect(ConfigureAgentSchema.safeParse({
+      name: 'Updated',
+      strategy: 'arbitrage',
+      budgetTon: 100,
+      riskLevel: 'low',
+    }).success).toBe(true);
+  });
+
+  it('rejects an empty object', () => {
+    expect(ConfigureAgentSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects invalid strategy', () => {
+    expect(ConfigureAgentSchema.safeParse({ strategy: 'bad' }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements all acceptance criteria from issue #309 — **Comprehensive API Input Validation**.

- **Schema validation** (`services/api/middleware/validate.ts`): `validateBody` validates request bodies against Zod schemas and returns structured 400 responses with field-level error details; `validateContentType` enforces `application/json` on body-carrying requests (415 on mismatch).
- **XSS sanitization** (`sanitizeString` / `sanitizeObject`): strips script/style blocks with content, strips remaining HTML tags, encodes residual `<`/`>`, and removes null bytes.
- **Rate limiting** (`services/api/middleware/rate-limit.ts`): in-memory sliding-window `RateLimiter`; pre-configured `createStandardRateLimit()` (100 req/15 min) and `createTradeRateLimit()` (10 req/min) factory helpers.
- **Security headers** (`services/api/middleware/security-headers.ts`): `getSecurityHeaders()` emits `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy`, `Cache-Control: no-store`, and optional HSTS.
- **CSRF token validation** (`isCsrfTokenValid`): constant-time comparison for state-mutating endpoints; safe methods bypass automatically.
- **Body size guard** (`isBodySizeAllowed`): rejects requests with `Content-Length` exceeding 100 KB.
- **Request timeout** (`withTimeout`): wraps any async handler with a configurable deadline; throws `RequestTimeoutError` on expiry.
- **Zod schemas** (`services/api/schemas/agent.ts`): `CreateAgentSchema` and `ConfigureAgentSchema` covering agent creation and reconfiguration payloads.

All middleware is framework-agnostic — operates on the existing `AgentControlRequest`/`AgentControlResponse` types, no Express dependency required.

## Test plan

- [x] `tests/api/validation.test.ts` — 60 new tests covering every acceptance criterion
- [x] Full suite: **7742 tests pass** across 119 test files (`npm test`)
- [x] Lint: 0 errors (`npm run lint`)

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)