### PR TITLE
feat(regulatory): integrate live sanctions screening providers (issue #341)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,19 @@ PORT=3000
 LOG_LEVEL=info
 
 # ============================================
+# Sanctions Screening Providers (Issue #341)
+# ============================================
+# LOCAL DEV ONLY — In production, load from secrets manager (see above).
+#
+# Primary on-chain screening (Chainalysis KYT)
+# Get key from: https://docs.chainalysis.com/api/kyt/
+CHAINALYSIS_API_KEY=
+
+# Entity/name-list screening (OpenSanctions)
+# Get key from: https://www.opensanctions.org/docs/api/
+OPENSANCTIONS_API_KEY=
+
+# ============================================
 # Compliance Enforcement (Issue #330)
 # ============================================
 # KYC/AML enforcement gates default to **enabled** so that any deployment

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-07T19:35:41.595Z for PR creation at branch issue-292-bd649a0c8fa3 for issue https://github.com/xlabtg/TONAIAgent/issues/292
 # Updated: 2026-04-22T22:25:46.239Z
+# Updated: 2026-04-22T23:05:09.174Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-07T19:35:41.595Z for PR creation at branch issue-292-bd649a0c8fa3 for issue https://github.com/xlabtg/TONAIAgent/issues/292
 # Updated: 2026-04-22T22:25:46.239Z
-# Updated: 2026-04-22T23:05:09.174Z

--- a/docs/regulatory-compliance.md
+++ b/docs/regulatory-compliance.md
@@ -240,11 +240,106 @@ Results are cached for 24 hours. Addresses are rarely removed from sanctions lis
 
 ### Integrating with external providers
 
-In production, replace the internal implementation in `SanctionsScreener.screenAddress()` with a call to your chosen provider:
+Configure live providers via `SanctionsScreenerConfig`. API keys must be loaded
+from `SecretsLoader` — never from `process.env` directly.
 
-- **Chainalysis KYT** — on-chain AML, real-time crypto transaction screening
-- **ComplyAdvantage** — KYC/AML data, entity screening, adverse media
-- **Elliptic** — crypto AML screening, wallet risk scoring
+#### Chainalysis KYT (on-chain address screening)
+
+```typescript
+import { createSanctionsScreener } from './services/regulatory/sanctions';
+import { createSecretsLoader } from './config/secrets';
+
+const secrets = createSecretsLoader({ backend: { provider: 'env' } });
+await secrets.load();
+
+const screener = createSanctionsScreener({
+  provider: 'chainalysis',
+  chainalysis: {
+    apiKey: await secrets.get('CHAINALYSIS_API_KEY'),
+  },
+  failClosed: true,   // block trade when provider is unreachable
+});
+```
+
+Required env var: `CHAINALYSIS_API_KEY`
+
+**Estimated cost:** Chainalysis KYT charges per-address screening call. Expect ~$0.01–$0.05 per call. At 10 000 screenings/month ≈ $100–$500/month depending on plan tier. Contact Chainalysis for volume pricing.
+
+#### OpenSanctions (entity name screening)
+
+```typescript
+const screener = createSanctionsScreener({
+  openSanctions: {
+    apiKey: await secrets.get('OPENSANCTIONS_API_KEY'),
+    minScore: 80,   // minimum fuzzy-match score (0-100)
+  },
+});
+```
+
+Required env var: `OPENSANCTIONS_API_KEY`
+
+**Estimated cost:** OpenSanctions offers a free bulk data download tier and a paid API. API calls are ~$0.001–$0.01 each. Bulk monthly snapshots are available from ~$250/month.
+
+#### Provider selection rationale
+
+| Need | Recommended provider |
+|------|---------------------|
+| On-chain crypto address screening | **Chainalysis KYT** (primary) |
+| Entity / name list screening (OFAC, EU, UN, UK HMT) | **OpenSanctions** (primary) |
+| Alternative on-chain screening | Elliptic |
+| Alternative name screening | ComplyAdvantage |
+
+Use Chainalysis for all blockchain-address checks and OpenSanctions for KYC name/entity checks. Both should be enabled in production.
+
+### Fail-closed policy
+
+When `failClosed: true` (the default):
+- If Chainalysis KYT is unreachable during address screening, the screener returns `isMatch: true` with `providerError: true` — blocking the trade.
+- If OpenSanctions is unreachable during entity screening, the screener returns `isMatch: true` with `providerError: true`.
+- The event `aml.transaction_blocked` is emitted with `reason: 'provider_error'`.
+
+When `failClosed: false`:
+- The screener falls back to the internal in-memory list. This means trades may pass if the provider is down and the address/entity is not in the local list.
+- **Only appropriate for development/testnet environments.**
+
+### Scheduled list downloader
+
+For supplementary local screening (OFAC SDN, EU, UN, UK HMT name lists):
+
+```typescript
+import { createListDownloader } from './services/regulatory/providers/list-downloader';
+
+const downloader = createListDownloader({
+  storagePath: '/data/sanctions',
+  staleAlertThresholdMs: 48 * 60 * 60 * 1000,  // 48 hours
+  onStaleAlert: (list, lastSuccessAt) => {
+    alertOpsTeam(`Sanctions list ${list} stale since ${lastSuccessAt}`);
+  },
+});
+
+// Run daily via cron
+await downloader.refreshAll();
+
+// Load results into the screener
+for (const list of ['ofac_sdn', 'eu_consolidated', 'un_security_council', 'uk_hm_treasury']) {
+  const entries = downloader.toSanctionsEntries(list);
+  screener.loadSanctionsList(list, entries);
+  screener.setListVersion(downloader.getSnapshot(list)?.version ?? 'unknown');
+}
+```
+
+The downloader stores a versioned, SHA-256-checksummed JSON snapshot for each list in `storagePath`. On startup call `downloader.loadFromDisk()` to restore the last good snapshot without waiting for a network download. The `onStaleAlert` callback fires when a list has not been successfully refreshed within `staleAlertThresholdMs` (default 48h).
+
+### Data flow
+
+```
+[Chainalysis KYT] ──┐
+                     ├──► SanctionsScreener ──► result (isMatch / riskScore)
+[OpenSanctions]  ──┤         │
+                     │         └──► audit log entry on positive hit
+[ListDownloader] ──┘              └──► aml.transaction_blocked event
+     (OFAC/EU/UN/UK)
+```
 
 ---
 

--- a/services/regulatory/providers/chainalysis.ts
+++ b/services/regulatory/providers/chainalysis.ts
@@ -1,0 +1,181 @@
+/**
+ * Chainalysis KYT (Know Your Transaction) Provider
+ *
+ * Integrates with the Chainalysis KYT v2 API for on-chain address screening.
+ * Docs: https://docs.chainalysis.com/api/kyt/
+ *
+ * Fail-closed: when the provider is unreachable and enforcement is enabled,
+ * this adapter throws so callers can block the trade.
+ */
+
+import type { SanctionsMatch, SanctionsList } from '../sanctions';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ChainalysisConfig {
+  apiKey: string;
+  /** Base URL — override for testing. Default: https://api.chainalysis.com */
+  baseUrl?: string;
+  /** Request timeout in ms. Default: 10 000 */
+  timeoutMs?: number;
+}
+
+export interface ChainalysisScreeningResult {
+  address: string;
+  cluster?: {
+    name: string;
+    category: string;
+  };
+  identifications: ChainalysisIdentification[];
+  riskScore: number; // 0-100
+  sanctioned: boolean;
+}
+
+interface ChainalysisIdentification {
+  category: string;
+  name: string;
+  description?: string;
+}
+
+/** Chainalysis API entity response shape (subset we use) */
+interface ChainalysisAddressResponse {
+  address: string;
+  risk: string;
+  cluster?: {
+    name: string;
+    category: string;
+  };
+  identifications?: Array<{
+    category: string;
+    name: string;
+    description?: string;
+  }>;
+}
+
+// ============================================================================
+// Risk category to SanctionsList mapping
+// ============================================================================
+
+const SANCTIONS_CATEGORY_MAP: Record<string, SanctionsList> = {
+  'sanctions': 'ofac_sdn',
+  'ofac_sdn': 'ofac_sdn',
+  'eu_sanctions': 'eu_consolidated',
+  'uk_hmt': 'uk_hm_treasury',
+  'un_sanctions': 'un_security_council',
+};
+
+function categoryToList(category: string): SanctionsList {
+  const key = category.toLowerCase().replace(/[\s-]/g, '_');
+  return SANCTIONS_CATEGORY_MAP[key] ?? 'ofac_sdn';
+}
+
+function riskStringToScore(risk: string): number {
+  switch (risk.toLowerCase()) {
+    case 'severe': return 100;
+    case 'high': return 85;
+    case 'medium': return 60;
+    case 'low': return 20;
+    default: return 0;
+  }
+}
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export class ChainalysisProvider {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+
+  constructor(config: ChainalysisConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? 'https://api.chainalysis.com').replace(/\/$/, '');
+    this.timeoutMs = config.timeoutMs ?? 10_000;
+  }
+
+  /**
+   * Screen a blockchain address via Chainalysis KYT.
+   * Throws on network errors so callers can fail-closed.
+   */
+  async screenAddress(address: string): Promise<ChainalysisScreeningResult> {
+    const url = `${this.baseUrl}/api/kyt/v2/users/${encodeURIComponent(address)}/summary`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Token': this.apiKey,
+          'Accept': 'application/json',
+        },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Chainalysis provider unreachable: ${msg}`);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (response.status === 404) {
+      // Address not known to Chainalysis — treat as clean
+      return {
+        address,
+        identifications: [],
+        riskScore: 0,
+        sanctioned: false,
+      };
+    }
+
+    if (!response.ok) {
+      throw new Error(`Chainalysis API error: HTTP ${response.status}`);
+    }
+
+    const data: ChainalysisAddressResponse = await response.json() as ChainalysisAddressResponse;
+    const riskScore = riskStringToScore(data.risk ?? '');
+    const identifications = data.identifications ?? [];
+    const sanctioned = identifications.some((id) =>
+      id.category.toLowerCase().includes('sanction')
+    );
+
+    return {
+      address: data.address ?? address,
+      cluster: data.cluster,
+      identifications: identifications.map((id) => ({
+        category: id.category,
+        name: id.name,
+        description: id.description,
+      })),
+      riskScore,
+      sanctioned,
+    };
+  }
+
+  /**
+   * Convert a Chainalysis result to the internal SanctionsMatch[] format.
+   */
+  toSanctionsMatches(result: ChainalysisScreeningResult): SanctionsMatch[] {
+    return result.identifications
+      .filter((id) => id.category.toLowerCase().includes('sanction'))
+      .map((id) => ({
+        list: categoryToList(id.category),
+        entityName: id.name,
+        entityType: 'crypto_address' as const,
+        matchScore: result.riskScore,
+        sanctionedSince: new Date(0), // Chainalysis doesn't expose listing date in this endpoint
+        programs: [],
+        aliases: [],
+        notes: id.description,
+      }));
+  }
+}
+
+export function createChainalysisProvider(config: ChainalysisConfig): ChainalysisProvider {
+  return new ChainalysisProvider(config);
+}

--- a/services/regulatory/providers/list-downloader.ts
+++ b/services/regulatory/providers/list-downloader.ts
@@ -1,0 +1,444 @@
+/**
+ * Sanctions List Downloader
+ *
+ * Downloads and parses official sanctions lists for local screening:
+ *   - OFAC SDN (US Office of Foreign Assets Control)
+ *   - EU Consolidated Sanctions List
+ *   - UN Security Council Consolidated List
+ *   - UK HM Treasury Consolidated List
+ *
+ * Stores a versioned, checksummed snapshot in durable storage and alerts
+ * when a refresh has not succeeded for more than 48 hours.
+ *
+ * Usage:
+ *   const downloader = createListDownloader({ storagePath: '/data/sanctions' });
+ *   await downloader.refreshAll();
+ *   const entries = downloader.getEntries('ofac_sdn');
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { SanctionsList, SanctionsMatch } from '../sanctions';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ListDownloaderConfig {
+  /** Directory for persisted list snapshots. Default: ./data/sanctions */
+  storagePath?: string;
+  /** Maximum age (ms) before a stale-list alert is fired. Default: 48h */
+  staleAlertThresholdMs?: number;
+  /** Request timeout per download (ms). Default: 30 000 */
+  downloadTimeoutMs?: number;
+  /** Callback invoked on stale list alert */
+  onStaleAlert?: (list: SanctionsList, lastSuccessAt: Date | null) => void;
+}
+
+export interface ListSnapshot {
+  list: SanctionsList;
+  version: string;      // ISO date string of successful download
+  checksum: string;     // SHA-256 hex of raw content
+  downloadedAt: Date;
+  entryCount: number;
+  entries: ParsedEntry[];
+}
+
+export interface ParsedEntry {
+  address?: string;
+  entityName: string;
+  entityType: 'individual' | 'entity' | 'vessel' | 'aircraft' | 'crypto_address';
+  programs: string[];
+  aliases: string[];
+  sanctionedSince: Date;
+}
+
+interface UrlConfig {
+  list: SanctionsList;
+  url: string;
+  format: 'ofac_csv' | 'eu_xml' | 'un_xml' | 'uk_csv';
+}
+
+// ============================================================================
+// List Sources
+// ============================================================================
+
+const LIST_SOURCES: UrlConfig[] = [
+  {
+    list: 'ofac_sdn',
+    url: 'https://www.treasury.gov/ofac/downloads/sdn.csv',
+    format: 'ofac_csv',
+  },
+  {
+    list: 'eu_consolidated',
+    url: 'https://webgate.ec.europa.eu/fsd/fsf/public/files/xmlFullSanctionsList_1_1/content',
+    format: 'eu_xml',
+  },
+  {
+    list: 'un_security_council',
+    url: 'https://scsanctions.un.org/resources/xml/en/consolidated.xml',
+    format: 'un_xml',
+  },
+  {
+    list: 'uk_hm_treasury',
+    url: 'https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.csv',
+    format: 'uk_csv',
+  },
+];
+
+// ============================================================================
+// Parsers
+// ============================================================================
+
+function parseOfacCsv(content: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    if (!line.trim() || line.startsWith('#') || line.startsWith('"Ent_num"')) continue;
+    const cols = splitCsvLine(line);
+    if (cols.length < 12) continue;
+
+    const name = (cols[1] ?? '').replace(/^"|"$/g, '').trim();
+    const type = (cols[2] ?? '').toLowerCase();
+    const programs = (cols[10] ?? '').split(';').map((p) => p.trim()).filter(Boolean);
+    const dateStr = cols[11] ?? '';
+
+    if (!name) continue;
+
+    const entityType: ParsedEntry['entityType'] =
+      type === 'individual' ? 'individual' :
+      type === 'vessel' ? 'vessel' :
+      type === 'aircraft' ? 'aircraft' :
+      'entity';
+
+    const sanctionedSince = dateStr ? new Date(dateStr) : new Date(0);
+
+    entries.push({
+      entityName: name,
+      entityType,
+      programs,
+      aliases: [],
+      sanctionedSince: isNaN(sanctionedSince.getTime()) ? new Date(0) : sanctionedSince,
+    });
+  }
+
+  return entries;
+}
+
+function parseEuXml(content: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  const subjectMatches = content.matchAll(/<sanctionEntity[^>]*>([\s\S]*?)<\/sanctionEntity>/gi);
+
+  for (const match of subjectMatches) {
+    const block = match[1] ?? '';
+
+    const nameMatch = block.match(/<wholeName[^>]*>([^<]+)<\/wholeName>/i);
+    const name = nameMatch?.[1]?.trim() ?? '';
+    if (!name) continue;
+
+    const dateMatch = block.match(/<regulationDate[^>]*>([^<]+)<\/regulationDate>/i);
+    const sanctionedSince = dateMatch?.[1] ? new Date(dateMatch[1]) : new Date(0);
+
+    const programMatches = [...block.matchAll(/<regulation[^>]*nameAlias[^>]*>([^<]+)<\/[^>]+>/gi)];
+    const programs = programMatches.map((m) => m[1]?.trim() ?? '').filter(Boolean);
+
+    const aliasMatches = [...block.matchAll(/<nameAlias[^>]*wholeName[^>]*>([^<]+)<\/[^>]+>/gi)];
+    const aliases = aliasMatches.map((m) => m[1]?.trim() ?? '').filter(Boolean);
+
+    entries.push({
+      entityName: name,
+      entityType: 'entity',
+      programs,
+      aliases,
+      sanctionedSince: isNaN(sanctionedSince.getTime()) ? new Date(0) : sanctionedSince,
+    });
+  }
+
+  return entries;
+}
+
+function parseUnXml(content: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  const individualMatches = content.matchAll(/<INDIVIDUAL>([\s\S]*?)<\/INDIVIDUAL>/gi);
+  const entityMatches = content.matchAll(/<ENTITY>([\s\S]*?)<\/ENTITY>/gi);
+
+  function extractName(block: string): string {
+    const first = block.match(/<FIRST_NAME>([^<]*)<\/FIRST_NAME>/i)?.[1]?.trim() ?? '';
+    const second = block.match(/<SECOND_NAME>([^<]*)<\/SECOND_NAME>/i)?.[1]?.trim() ?? '';
+    const third = block.match(/<THIRD_NAME>([^<]*)<\/THIRD_NAME>/i)?.[1]?.trim() ?? '';
+    const full = [first, second, third].filter(Boolean).join(' ');
+    if (full) return full;
+    return block.match(/<NAME>([^<]+)<\/NAME>/i)?.[1]?.trim() ?? '';
+  }
+
+  function extractDate(block: string): Date {
+    const dateStr = block.match(/<LISTED_ON>([^<]+)<\/LISTED_ON>/i)?.[1]?.trim() ?? '';
+    const d = new Date(dateStr);
+    return isNaN(d.getTime()) ? new Date(0) : d;
+  }
+
+  for (const m of individualMatches) {
+    const block = m[1] ?? '';
+    const name = extractName(block);
+    if (!name) continue;
+    entries.push({
+      entityName: name,
+      entityType: 'individual',
+      programs: [],
+      aliases: [],
+      sanctionedSince: extractDate(block),
+    });
+  }
+
+  for (const m of entityMatches) {
+    const block = m[1] ?? '';
+    const name = extractName(block);
+    if (!name) continue;
+    entries.push({
+      entityName: name,
+      entityType: 'entity',
+      programs: [],
+      aliases: [],
+      sanctionedSince: extractDate(block),
+    });
+  }
+
+  return entries;
+}
+
+function parseUkCsv(content: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    if (!line.trim() || line.startsWith('Name 6')) continue;
+    const cols = splitCsvLine(line);
+    if (cols.length < 6) continue;
+
+    const name = [cols[0], cols[1], cols[2], cols[3], cols[4], cols[5]]
+      .map((c) => c.replace(/^"|"$/g, '').trim())
+      .filter(Boolean)
+      .join(' ');
+
+    if (!name) continue;
+
+    const groupType = (cols[6] ?? '').toLowerCase().trim().replace(/^"|"$/g, '');
+    const entityType: ParsedEntry['entityType'] = groupType === 'individual' ? 'individual' : 'entity';
+
+    const dateStr = (cols[26] ?? '').replace(/^"|"$/g, '').trim();
+    const sanctionedSince = dateStr ? new Date(dateStr) : new Date(0);
+
+    entries.push({
+      entityName: name,
+      entityType,
+      programs: [],
+      aliases: [],
+      sanctionedSince: isNaN(sanctionedSince.getTime()) ? new Date(0) : sanctionedSince,
+    });
+  }
+
+  return entries;
+}
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+function parseContent(content: string, format: UrlConfig['format']): ParsedEntry[] {
+  switch (format) {
+    case 'ofac_csv': return parseOfacCsv(content);
+    case 'eu_xml':   return parseEuXml(content);
+    case 'un_xml':   return parseUnXml(content);
+    case 'uk_csv':   return parseUkCsv(content);
+  }
+}
+
+// ============================================================================
+// Downloader
+// ============================================================================
+
+export class ListDownloader {
+  private readonly storagePath: string;
+  private readonly staleAlertThresholdMs: number;
+  private readonly downloadTimeoutMs: number;
+  private readonly onStaleAlert?: (list: SanctionsList, lastSuccessAt: Date | null) => void;
+
+  private snapshots: Map<SanctionsList, ListSnapshot> = new Map();
+  private lastSuccessAt: Map<SanctionsList, Date> = new Map();
+
+  constructor(config: ListDownloaderConfig = {}) {
+    this.storagePath = config.storagePath ?? path.join(process.cwd(), 'data', 'sanctions');
+    this.staleAlertThresholdMs = config.staleAlertThresholdMs ?? 48 * 60 * 60 * 1000;
+    this.downloadTimeoutMs = config.downloadTimeoutMs ?? 30_000;
+    this.onStaleAlert = config.onStaleAlert;
+  }
+
+  // ============================================================================
+  // Public API
+  // ============================================================================
+
+  /** Download and parse all configured lists. */
+  async refreshAll(): Promise<{ list: SanctionsList; success: boolean; error?: string }[]> {
+    const results = await Promise.allSettled(
+      LIST_SOURCES.map((src) => this.refreshList(src))
+    );
+
+    return LIST_SOURCES.map((src, i) => {
+      const r = results[i];
+      if (r && r.status === 'fulfilled') {
+        return { list: src.list, success: true };
+      }
+      const err = r && r.status === 'rejected' ? (r.reason as Error).message : 'unknown';
+      return { list: src.list, success: false, error: err };
+    });
+  }
+
+  /** Refresh a single list. */
+  async refreshList(src: UrlConfig): Promise<ListSnapshot> {
+    const content = await this.download(src.url);
+    const checksum = crypto.createHash('sha256').update(content).digest('hex');
+    const entries = parseContent(content, src.format);
+    const version = new Date().toISOString();
+
+    const snapshot: ListSnapshot = {
+      list: src.list,
+      version,
+      checksum,
+      downloadedAt: new Date(),
+      entryCount: entries.length,
+      entries,
+    };
+
+    this.snapshots.set(src.list, snapshot);
+    this.lastSuccessAt.set(src.list, new Date());
+    this.persistSnapshot(snapshot);
+    return snapshot;
+  }
+
+  /** Get all parsed entries for a list. Returns [] if list not loaded. */
+  getEntries(list: SanctionsList): ParsedEntry[] {
+    return this.snapshots.get(list)?.entries ?? [];
+  }
+
+  /** Get the current snapshot metadata for a list. */
+  getSnapshot(list: SanctionsList): ListSnapshot | undefined {
+    return this.snapshots.get(list);
+  }
+
+  /** Load previously persisted snapshots from disk (call on startup). */
+  loadFromDisk(): void {
+    for (const src of LIST_SOURCES) {
+      const filePath = this.snapshotPath(src.list);
+      if (!fs.existsSync(filePath)) continue;
+      try {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        const snapshot = JSON.parse(raw) as ListSnapshot;
+        snapshot.downloadedAt = new Date(snapshot.downloadedAt);
+        snapshot.entries = snapshot.entries.map((e) => ({
+          ...e,
+          sanctionedSince: new Date(e.sanctionedSince),
+        }));
+        this.snapshots.set(src.list, snapshot);
+        this.lastSuccessAt.set(src.list, snapshot.downloadedAt);
+      } catch {
+        // Corrupted snapshot — will be refreshed on next download
+      }
+    }
+  }
+
+  /**
+   * Check all lists for staleness and fire the alert callback for any
+   * list that has not been successfully refreshed within the threshold.
+   */
+  checkStaleness(): void {
+    const now = Date.now();
+    for (const src of LIST_SOURCES) {
+      const lastSuccess = this.lastSuccessAt.get(src.list) ?? null;
+      const age = lastSuccess ? now - lastSuccess.getTime() : Infinity;
+      if (age > this.staleAlertThresholdMs) {
+        this.onStaleAlert?.(src.list, lastSuccess);
+      }
+    }
+  }
+
+  /**
+   * Convert loaded entries for a given list into SanctionsMatch[] objects
+   * suitable for passing to SanctionsScreener.loadSanctionsList().
+   */
+  toSanctionsEntries(list: SanctionsList): Array<{ address: string; match: SanctionsMatch }> {
+    const snapshot = this.snapshots.get(list);
+    if (!snapshot) return [];
+
+    return snapshot.entries.map((entry) => ({
+      address: entry.address ?? entry.entityName,
+      match: {
+        list,
+        entityName: entry.entityName,
+        entityType: entry.entityType,
+        matchScore: 100,
+        sanctionedSince: entry.sanctionedSince,
+        programs: entry.programs,
+        aliases: entry.aliases,
+      },
+    }));
+  }
+
+  // ============================================================================
+  // Private
+  // ============================================================================
+
+  private async download(url: string): Promise<string> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.downloadTimeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Download failed for ${url}: ${msg}`);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Download failed for ${url}: HTTP ${response.status}`);
+    }
+
+    return response.text();
+  }
+
+  private snapshotPath(list: SanctionsList): string {
+    return path.join(this.storagePath, `${list}.json`);
+  }
+
+  private persistSnapshot(snapshot: ListSnapshot): void {
+    try {
+      fs.mkdirSync(this.storagePath, { recursive: true });
+      fs.writeFileSync(this.snapshotPath(snapshot.list), JSON.stringify(snapshot, null, 2), 'utf8');
+    } catch {
+      // Non-fatal: in-memory snapshot is still valid
+    }
+  }
+}
+
+export function createListDownloader(config?: ListDownloaderConfig): ListDownloader {
+  return new ListDownloader(config);
+}

--- a/services/regulatory/providers/opensanctions.ts
+++ b/services/regulatory/providers/opensanctions.ts
@@ -1,0 +1,191 @@
+/**
+ * OpenSanctions Provider
+ *
+ * Integrates with the OpenSanctions API for name/entity screening against
+ * OFAC SDN, EU Consolidated, UN Security Council, and UK HMT lists.
+ * Docs: https://www.opensanctions.org/docs/api/
+ *
+ * Fail-closed: throws on provider unreachability so callers can block trades.
+ */
+
+import type { SanctionsMatch, SanctionsList } from '../sanctions';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface OpenSanctionsConfig {
+  apiKey: string;
+  /** Base URL. Default: https://api.opensanctions.org */
+  baseUrl?: string;
+  /** Request timeout in ms. Default: 10 000 */
+  timeoutMs?: number;
+  /** Minimum match score (0-100) to include in results. Default: 70 */
+  minScore?: number;
+}
+
+export interface OpenSanctionsMatch {
+  id: string;
+  name: string;
+  score: number;
+  datasets: string[];
+  properties: {
+    name?: string[];
+    alias?: string[];
+    country?: string[];
+    program?: string[];
+    topics?: string[];
+    createdAt?: string[];
+  };
+}
+
+export interface OpenSanctionsResult {
+  query: string;
+  matches: OpenSanctionsMatch[];
+  hasHit: boolean;
+}
+
+/** OpenSanctions API response shape */
+interface OpenSanctionsApiResponse {
+  results: Array<{
+    id: string;
+    caption: string;
+    score: number;
+    datasets: string[];
+    properties: Record<string, string[]>;
+  }>;
+  total: { value: number };
+}
+
+// ============================================================================
+// Dataset → SanctionsList mapping
+// ============================================================================
+
+const DATASET_TO_LIST: Record<string, SanctionsList> = {
+  'us_ofac_sdn': 'ofac_sdn',
+  'us_ofac_cons': 'ofac_sdn',
+  'eu_fsf': 'eu_consolidated',
+  'un_sc_sanctions': 'un_security_council',
+  'gb_hmt_sanctions': 'uk_hm_treasury',
+};
+
+function datasetToList(dataset: string): SanctionsList {
+  for (const [prefix, list] of Object.entries(DATASET_TO_LIST)) {
+    if (dataset.startsWith(prefix)) return list;
+  }
+  return 'ofac_sdn';
+}
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+export class OpenSanctionsProvider {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly minScore: number;
+
+  constructor(config: OpenSanctionsConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? 'https://api.opensanctions.org').replace(/\/$/, '');
+    this.timeoutMs = config.timeoutMs ?? 10_000;
+    this.minScore = config.minScore ?? 70;
+  }
+
+  /**
+   * Search for an entity by name against all sanctions datasets.
+   * Throws on network errors so callers can fail-closed.
+   */
+  async screenEntity(entityName: string): Promise<OpenSanctionsResult> {
+    const url = `${this.baseUrl}/match/sanctions/`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    const body = JSON.stringify({
+      queries: {
+        q: {
+          schema: 'Thing',
+          properties: { name: [entityName] },
+        },
+      },
+    });
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `ApiKey ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`OpenSanctions provider unreachable: ${msg}`);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      throw new Error(`OpenSanctions API error: HTTP ${response.status}`);
+    }
+
+    const data = await response.json() as { responses: { q: OpenSanctionsApiResponse } };
+    const results = data.responses?.q?.results ?? [];
+
+    const matches: OpenSanctionsMatch[] = results
+      .filter((r) => r.score >= this.minScore)
+      .map((r) => ({
+        id: r.id,
+        name: r.caption,
+        score: r.score,
+        datasets: r.datasets,
+        properties: {
+          name: r.properties['name'],
+          alias: r.properties['alias'],
+          country: r.properties['country'],
+          program: r.properties['program'],
+          topics: r.properties['topics'],
+          createdAt: r.properties['createdAt'],
+        },
+      }));
+
+    return {
+      query: entityName,
+      matches,
+      hasHit: matches.length > 0,
+    };
+  }
+
+  /**
+   * Convert OpenSanctions matches to internal SanctionsMatch[] format.
+   */
+  toSanctionsMatches(result: OpenSanctionsResult): SanctionsMatch[] {
+    return result.matches.map((match) => {
+      const primaryDataset = match.datasets[0] ?? '';
+      const list = datasetToList(primaryDataset);
+
+      const createdAtStr = match.properties.createdAt?.[0];
+      const sanctionedSince = createdAtStr ? new Date(createdAtStr) : new Date(0);
+
+      return {
+        list,
+        entityName: match.name,
+        entityType: 'individual' as const,
+        matchScore: Math.round(match.score),
+        sanctionedSince,
+        programs: match.properties.program ?? [],
+        aliases: match.properties.alias ?? [],
+      };
+    });
+  }
+}
+
+export function createOpenSanctionsProvider(config: OpenSanctionsConfig): OpenSanctionsProvider {
+  return new OpenSanctionsProvider(config);
+}

--- a/services/regulatory/sanctions.ts
+++ b/services/regulatory/sanctions.ts
@@ -7,15 +7,28 @@
  *   - UN Security Council Sanctions List
  *   - UK HM Treasury Consolidated List
  *
- * Designed for integration with external services (Chainalysis, ComplyAdvantage,
- * Elliptic) while providing a complete in-memory implementation for testing
- * and development environments.
+ * Primary on-chain screening: Chainalysis KYT
+ * Name/entity screening:      OpenSanctions
+ * Fallback:                   Internal in-memory list (pre-loaded via ListDownloader)
  *
- * Results are cached for 24 hours per the industry standard — addresses are
- * rarely removed from sanctions lists.
+ * Fail-closed policy: when a live provider is configured and unreachable, the
+ * screener blocks (returns isMatch=true with a provider-error flag) instead of
+ * silently passing the address through.
+ *
+ * Results are cached per (address, listVersion) for 24 hours.
  */
 
 import { RegulatoryEventCallback, RegulatoryEvent, RegulatoryEventType } from './types';
+import {
+  ChainalysisProvider,
+  ChainalysisConfig,
+  createChainalysisProvider,
+} from './providers/chainalysis';
+import {
+  OpenSanctionsProvider,
+  OpenSanctionsConfig,
+  createOpenSanctionsProvider,
+} from './providers/opensanctions';
 
 // ============================================================================
 // Types
@@ -44,7 +57,13 @@ export interface SanctionsScreeningResult {
   riskScore: number; // 0-100
   cachedAt: Date;
   cacheExpiresAt: Date;
-  provider: 'internal' | 'chainalysis' | 'complyadvantage' | 'elliptic';
+  provider: 'internal' | 'chainalysis' | 'complyadvantage' | 'elliptic' | 'opensanctions';
+  /** True when the result is a fail-closed block due to a provider error */
+  providerError?: boolean;
+  /** Populated when providerError is true */
+  providerErrorMessage?: string;
+  /** The list version this result was cached against */
+  listVersion?: string;
 }
 
 export interface EntitySanctionsResult {
@@ -54,7 +73,30 @@ export interface EntitySanctionsResult {
   riskScore: number;
   screened: boolean;
   screenedAt: Date;
+  provider: 'internal' | 'opensanctions';
+  providerError?: boolean;
+  providerErrorMessage?: string;
 }
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+export interface SanctionsMetrics {
+  totalScreenings: number;
+  sanctionedAddressCount: number;
+  cachedResults: number;
+  /** Counters by provider and result (match|no_match|error) */
+  checkTotal: Record<string, number>;
+  /** Total duration in ms across all live provider calls */
+  totalProviderDurationMs: number;
+  /** Number of live provider calls */
+  providerCallCount: number;
+}
+
+// ============================================================================
+// Config
+// ============================================================================
 
 export interface SanctionsScreenerConfig {
   /** Lists to screen against */
@@ -65,13 +107,27 @@ export interface SanctionsScreenerConfig {
   provider?: 'internal' | 'chainalysis' | 'complyadvantage' | 'elliptic';
   /** Minimum match score to consider a hit (0-100) */
   matchThreshold?: number;
+  /**
+   * When true and a live provider is configured but unreachable, the screener
+   * blocks (isMatch=true, providerError=true) rather than silently passing.
+   * Default: true
+   */
+  failClosed?: boolean;
+  /** Chainalysis KYT provider config. Required when provider='chainalysis'. */
+  chainalysis?: ChainalysisConfig;
+  /** OpenSanctions provider config for entity name screening. */
+  openSanctions?: OpenSanctionsConfig;
+  /** A string identifying the current list data version (e.g. ISO date). Used for cache keying. */
+  listVersion?: string;
 }
 
-const DEFAULT_CONFIG: Required<SanctionsScreenerConfig> = {
+const DEFAULT_CONFIG: Required<Omit<SanctionsScreenerConfig, 'chainalysis' | 'openSanctions'>> = {
   lists: ['ofac_sdn', 'eu_consolidated', 'un_security_council', 'uk_hm_treasury'],
   cacheDurationMs: 24 * 60 * 60 * 1000, // 24 hours
   provider: 'internal',
   matchThreshold: 85,
+  failClosed: true,
+  listVersion: 'default',
 };
 
 // ============================================================================
@@ -82,36 +138,64 @@ const DEFAULT_CONFIG: Required<SanctionsScreenerConfig> = {
  * SanctionsScreener — screens blockchain addresses and entities against
  * major international sanctions lists.
  *
- * In production, wire up the `screenAddress` and `screenEntity` methods
- * to call your chosen provider (Chainalysis KYT, ComplyAdvantage, Elliptic).
- * The in-memory blocklist handles both demo/test environments and manual
- * additions from compliance staff.
+ * Provider hierarchy:
+ *   1. Chainalysis KYT (if configured) — for address screening
+ *   2. OpenSanctions (if configured) — for entity name screening
+ *   3. Internal in-memory list — fallback / pre-loaded list data
  *
  * @example
  * ```typescript
- * const screener = createSanctionsScreener();
- *
- * // Pre-load known-bad addresses (e.g. from OFAC download)
- * screener.addSanctionedAddress('EQC...', [{
- *   list: 'ofac_sdn', entityName: 'Sanctioned Entity', entityType: 'crypto_address',
- *   matchScore: 100, sanctionedSince: new Date('2022-01-01'), programs: ['CYBER2'], aliases: []
- * }]);
+ * // Production: Chainalysis + OpenSanctions
+ * const screener = createSanctionsScreener({
+ *   provider: 'chainalysis',
+ *   chainalysis: { apiKey: secrets.get('CHAINALYSIS_API_KEY') },
+ *   openSanctions: { apiKey: secrets.get('OPENSANCTIONS_API_KEY') },
+ *   failClosed: true,
+ * });
  *
  * const result = await screener.screenAddress('EQC...');
- * if (result.isMatch) {
- *   throw new Error('Transaction to sanctioned address blocked');
- * }
+ * if (result.isMatch) throw new Error('Sanctioned address blocked');
+ *
+ * // Development: internal list only
+ * const screener = createSanctionsScreener({ provider: 'internal' });
+ * screener.addSanctionedAddress('EQC...', [{ list: 'ofac_sdn', ... }]);
  * ```
  */
 export class SanctionsScreener {
-  private readonly config: Required<SanctionsScreenerConfig>;
+  private readonly config: Required<Omit<SanctionsScreenerConfig, 'chainalysis' | 'openSanctions'>>;
+  private readonly chainalysis?: ChainalysisProvider;
+  private readonly openSanctions?: OpenSanctionsProvider;
+
+  /** Cache key: `${address}::${listVersion}` → result */
   private readonly addressCache: Map<string, SanctionsScreeningResult> = new Map();
   private readonly sanctionedAddresses: Map<string, SanctionsMatch[]> = new Map();
   private readonly eventListeners: RegulatoryEventCallback[] = [];
-  private screeningCounter = 0;
+
+  private readonly metrics: SanctionsMetrics = {
+    totalScreenings: 0,
+    sanctionedAddressCount: 0,
+    cachedResults: 0,
+    checkTotal: {},
+    totalProviderDurationMs: 0,
+    providerCallCount: 0,
+  };
 
   constructor(config: SanctionsScreenerConfig = {}) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.config = {
+      lists: config.lists ?? DEFAULT_CONFIG.lists,
+      cacheDurationMs: config.cacheDurationMs ?? DEFAULT_CONFIG.cacheDurationMs,
+      provider: config.provider ?? DEFAULT_CONFIG.provider,
+      matchThreshold: config.matchThreshold ?? DEFAULT_CONFIG.matchThreshold,
+      failClosed: config.failClosed ?? DEFAULT_CONFIG.failClosed,
+      listVersion: config.listVersion ?? DEFAULT_CONFIG.listVersion,
+    };
+
+    if (config.chainalysis) {
+      this.chainalysis = createChainalysisProvider(config.chainalysis);
+    }
+    if (config.openSanctions) {
+      this.openSanctions = createOpenSanctionsProvider(config.openSanctions);
+    }
   }
 
   // ============================================================================
@@ -120,48 +204,38 @@ export class SanctionsScreener {
 
   /**
    * Screen a blockchain address against all configured sanctions lists.
-   * Results are cached for 24 hours.
+   *
+   * Provider precedence:
+   *   1. Chainalysis KYT (if apiKey configured)
+   *   2. Internal in-memory list
+   *
+   * Results are cached per (address, listVersion) for cacheDurationMs.
    */
   async screenAddress(address: string): Promise<SanctionsScreeningResult> {
     const normalised = address.trim();
+    const cacheKey = `${normalised}::${this.config.listVersion}`;
 
-    // Check cache first
-    const cached = this.addressCache.get(normalised);
+    const cached = this.addressCache.get(cacheKey);
     if (cached && cached.cacheExpiresAt > new Date()) {
+      this.incrementMetric('cached_hit', 'cached');
       return cached;
     }
 
-    const matches = this.sanctionedAddresses.get(normalised) ?? [];
-    const isMatch = matches.some((m) => m.matchScore >= this.config.matchThreshold);
-    const riskScore = matches.length > 0 ? Math.max(...matches.map((m) => m.matchScore)) : 0;
+    let result: SanctionsScreeningResult;
 
-    const now = new Date();
-    const result: SanctionsScreeningResult = {
-      address: normalised,
-      screened: true,
-      isMatch,
-      matches,
-      riskScore,
-      cachedAt: now,
-      cacheExpiresAt: new Date(now.getTime() + this.config.cacheDurationMs),
-      provider: this.config.provider,
-    };
+    if (this.chainalysis) {
+      result = await this.screenAddressViaChainalysis(normalised);
+    } else {
+      result = this.screenAddressInternal(normalised);
+    }
 
-    this.addressCache.set(normalised, result);
-    this.screeningCounter++;
+    this.addressCache.set(cacheKey, result);
+    this.metrics.totalScreenings++;
+    this.metrics.sanctionedAddressCount = this.sanctionedAddresses.size;
+    this.metrics.cachedResults = this.addressCache.size;
 
-    if (isMatch) {
-      this.emitEvent({
-        type: 'aml.transaction_blocked',
-        timestamp: now,
-        payload: {
-          address: normalised,
-          matchCount: matches.length,
-          riskScore,
-          lists: matches.map((m) => m.list),
-        },
-        source: 'sanctions-screener',
-      });
+    if (result.isMatch && !result.providerError) {
+      this.emitMatchEvent(normalised, result);
     }
 
     return result;
@@ -169,32 +243,16 @@ export class SanctionsScreener {
 
   /**
    * Screen an entity (person or organisation) by name against sanctions lists.
+   *
+   * Provider precedence:
+   *   1. OpenSanctions (if apiKey configured)
+   *   2. Internal in-memory entity name search
    */
   async screenEntity(entityName: string): Promise<EntitySanctionsResult> {
-    const normalised = entityName.trim().toLowerCase();
-
-    const matches: SanctionsMatch[] = [];
-    for (const matchList of this.sanctionedAddresses.values()) {
-      for (const match of matchList) {
-        const nameLower = match.entityName.toLowerCase();
-        const aliasMatch = match.aliases.some((a) => a.toLowerCase().includes(normalised) || normalised.includes(a.toLowerCase()));
-        if (nameLower.includes(normalised) || normalised.includes(nameLower) || aliasMatch) {
-          matches.push(match);
-        }
-      }
+    if (this.openSanctions) {
+      return this.screenEntityViaOpenSanctions(entityName);
     }
-
-    const isMatch = matches.some((m) => m.matchScore >= this.config.matchThreshold);
-    const riskScore = matches.length > 0 ? Math.max(...matches.map((m) => m.matchScore)) : 0;
-
-    return {
-      entityName,
-      isMatch,
-      matches,
-      riskScore,
-      screened: true,
-      screenedAt: new Date(),
-    };
+    return this.screenEntityInternal(entityName);
   }
 
   // ============================================================================
@@ -209,8 +267,7 @@ export class SanctionsScreener {
     const normalised = address.trim();
     const existing = this.sanctionedAddresses.get(normalised) ?? [];
     this.sanctionedAddresses.set(normalised, [...existing, ...matches]);
-    // Invalidate any cached result for this address
-    this.addressCache.delete(normalised);
+    this.invalidateAddressCache(normalised);
   }
 
   /**
@@ -219,14 +276,13 @@ export class SanctionsScreener {
   removeSanctionedAddress(address: string): void {
     const normalised = address.trim();
     this.sanctionedAddresses.delete(normalised);
-    this.addressCache.delete(normalised);
+    this.invalidateAddressCache(normalised);
   }
 
   /**
    * Bulk-load a sanctions list. Clears and replaces entries for the specified list.
    */
   loadSanctionsList(list: SanctionsList, entries: Array<{ address: string; match: SanctionsMatch }>): void {
-    // Remove existing entries for this list
     for (const [addr, matches] of this.sanctionedAddresses.entries()) {
       const filtered = matches.filter((m) => m.list !== list);
       if (filtered.length === 0) {
@@ -234,10 +290,9 @@ export class SanctionsScreener {
       } else {
         this.sanctionedAddresses.set(addr, filtered);
       }
-      this.addressCache.delete(addr);
+      this.invalidateAddressCache(addr);
     }
 
-    // Add new entries
     for (const entry of entries) {
       this.addSanctionedAddress(entry.address, [{ ...entry.match, list }]);
     }
@@ -259,16 +314,20 @@ export class SanctionsScreener {
     return matches.some((m) => m.matchScore >= this.config.matchThreshold);
   }
 
+  /**
+   * Update the list version string. All existing address cache entries become
+   * stale (they will be re-screened on next access).
+   */
+  setListVersion(version: string): void {
+    (this.config as { listVersion: string }).listVersion = version;
+  }
+
   // ============================================================================
   // Metrics
   // ============================================================================
 
-  getMetrics(): { totalScreenings: number; sanctionedAddressCount: number; cachedResults: number } {
-    return {
-      totalScreenings: this.screeningCounter,
-      sanctionedAddressCount: this.sanctionedAddresses.size,
-      cachedResults: this.addressCache.size,
-    };
+  getMetrics(): SanctionsMetrics {
+    return { ...this.metrics, checkTotal: { ...this.metrics.checkTotal } };
   }
 
   // ============================================================================
@@ -277,6 +336,232 @@ export class SanctionsScreener {
 
   onEvent(callback: RegulatoryEventCallback): void {
     this.eventListeners.push(callback);
+  }
+
+  // ============================================================================
+  // Private — Provider Calls
+  // ============================================================================
+
+  private async screenAddressViaChainalysis(address: string): Promise<SanctionsScreeningResult> {
+    const now = new Date();
+    const start = Date.now();
+
+    try {
+      const chainalysisResult = await this.chainalysis!.screenAddress(address);
+      const durationMs = Date.now() - start;
+      this.metrics.totalProviderDurationMs += durationMs;
+      this.metrics.providerCallCount++;
+
+      const matches = this.chainalysis!.toSanctionsMatches(chainalysisResult);
+      const isMatch = chainalysisResult.sanctioned &&
+        matches.some((m) => m.matchScore >= this.config.matchThreshold);
+      const riskScore = chainalysisResult.riskScore;
+
+      const result: SanctionsScreeningResult = {
+        address,
+        screened: true,
+        isMatch,
+        matches,
+        riskScore,
+        cachedAt: now,
+        cacheExpiresAt: new Date(now.getTime() + this.config.cacheDurationMs),
+        provider: 'chainalysis',
+        listVersion: this.config.listVersion,
+      };
+
+      this.incrementMetric('chainalysis', isMatch ? 'match' : 'no_match');
+      return result;
+
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      this.metrics.totalProviderDurationMs += durationMs;
+      this.metrics.providerCallCount++;
+      this.incrementMetric('chainalysis', 'error');
+
+      const message = err instanceof Error ? err.message : String(err);
+
+      if (this.config.failClosed) {
+        // Block the trade — provider unavailable, fail-closed
+        const result: SanctionsScreeningResult = {
+          address,
+          screened: false,
+          isMatch: true,
+          matches: [],
+          riskScore: 100,
+          cachedAt: now,
+          // Don't cache error results for long — retry quickly
+          cacheExpiresAt: new Date(now.getTime() + 60_000),
+          provider: 'chainalysis',
+          providerError: true,
+          providerErrorMessage: message,
+          listVersion: this.config.listVersion,
+        };
+
+        this.emitEvent({
+          type: 'aml.transaction_blocked',
+          timestamp: now,
+          payload: { address, reason: 'provider_error', provider: 'chainalysis', error: message },
+          source: 'sanctions-screener',
+        });
+
+        return result;
+      }
+
+      // Fail-open fallback: use internal list
+      return this.screenAddressInternal(address);
+    }
+  }
+
+  private screenAddressInternal(address: string): SanctionsScreeningResult {
+    const now = new Date();
+    const matches = this.sanctionedAddresses.get(address) ?? [];
+    const isMatch = matches.some((m) => m.matchScore >= this.config.matchThreshold);
+    const riskScore = matches.length > 0 ? Math.max(...matches.map((m) => m.matchScore)) : 0;
+
+    this.incrementMetric('internal', isMatch ? 'match' : 'no_match');
+
+    return {
+      address,
+      screened: true,
+      isMatch,
+      matches,
+      riskScore,
+      cachedAt: now,
+      cacheExpiresAt: new Date(now.getTime() + this.config.cacheDurationMs),
+      provider: 'internal',
+      listVersion: this.config.listVersion,
+    };
+  }
+
+  private async screenEntityViaOpenSanctions(entityName: string): Promise<EntitySanctionsResult> {
+    const now = new Date();
+    const start = Date.now();
+
+    try {
+      const osResult = await this.openSanctions!.screenEntity(entityName);
+      const durationMs = Date.now() - start;
+      this.metrics.totalProviderDurationMs += durationMs;
+      this.metrics.providerCallCount++;
+
+      const matches = this.openSanctions!.toSanctionsMatches(osResult);
+      const isMatch = osResult.hasHit && matches.some((m) => m.matchScore >= this.config.matchThreshold);
+      const riskScore = matches.length > 0 ? Math.max(...matches.map((m) => m.matchScore)) : 0;
+
+      this.incrementMetric('opensanctions', isMatch ? 'match' : 'no_match');
+
+      if (isMatch) {
+        this.emitEvent({
+          type: 'aml.transaction_flagged',
+          timestamp: now,
+          payload: {
+            entityName,
+            matchCount: matches.length,
+            riskScore,
+            lists: [...new Set(matches.map((m) => m.list))],
+            provider: 'opensanctions',
+          },
+          source: 'sanctions-screener',
+        });
+      }
+
+      return {
+        entityName,
+        isMatch,
+        matches,
+        riskScore,
+        screened: true,
+        screenedAt: now,
+        provider: 'opensanctions',
+      };
+
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      this.metrics.totalProviderDurationMs += durationMs;
+      this.metrics.providerCallCount++;
+      this.incrementMetric('opensanctions', 'error');
+
+      const message = err instanceof Error ? err.message : String(err);
+
+      if (this.config.failClosed) {
+        return {
+          entityName,
+          isMatch: true,
+          matches: [],
+          riskScore: 100,
+          screened: false,
+          screenedAt: now,
+          provider: 'opensanctions',
+          providerError: true,
+          providerErrorMessage: message,
+        };
+      }
+
+      return this.screenEntityInternal(entityName);
+    }
+  }
+
+  private screenEntityInternal(entityName: string): EntitySanctionsResult {
+    const normalised = entityName.trim().toLowerCase();
+    const matches: SanctionsMatch[] = [];
+
+    for (const matchList of this.sanctionedAddresses.values()) {
+      for (const match of matchList) {
+        const nameLower = match.entityName.toLowerCase();
+        const aliasMatch = match.aliases.some(
+          (a) => a.toLowerCase().includes(normalised) || normalised.includes(a.toLowerCase())
+        );
+        if (nameLower.includes(normalised) || normalised.includes(nameLower) || aliasMatch) {
+          matches.push(match);
+        }
+      }
+    }
+
+    const isMatch = matches.some((m) => m.matchScore >= this.config.matchThreshold);
+    const riskScore = matches.length > 0 ? Math.max(...matches.map((m) => m.matchScore)) : 0;
+
+    this.incrementMetric('internal', isMatch ? 'match' : 'no_match');
+
+    return {
+      entityName,
+      isMatch,
+      matches,
+      riskScore,
+      screened: true,
+      screenedAt: new Date(),
+      provider: 'internal',
+    };
+  }
+
+  // ============================================================================
+  // Private — Helpers
+  // ============================================================================
+
+  private invalidateAddressCache(address: string): void {
+    for (const key of this.addressCache.keys()) {
+      if (key.startsWith(`${address}::`)) {
+        this.addressCache.delete(key);
+      }
+    }
+  }
+
+  private incrementMetric(provider: string, result: 'match' | 'no_match' | 'error' | 'cached'): void {
+    const key = `${provider}:${result}`;
+    this.metrics.checkTotal[key] = (this.metrics.checkTotal[key] ?? 0) + 1;
+  }
+
+  private emitMatchEvent(address: string, result: SanctionsScreeningResult): void {
+    this.emitEvent({
+      type: 'aml.transaction_blocked',
+      timestamp: new Date(),
+      payload: {
+        address,
+        matchCount: result.matches.length,
+        riskScore: result.riskScore,
+        lists: result.matches.map((m) => m.list),
+        provider: result.provider,
+      },
+      source: 'sanctions-screener',
+    });
   }
 
   private emitEvent(event: Omit<RegulatoryEvent, 'correlationId'> & { type: RegulatoryEventType }): void {

--- a/tests/regulatory/sanctions-integration.test.ts
+++ b/tests/regulatory/sanctions-integration.test.ts
@@ -1,0 +1,741 @@
+/**
+ * Sanctions Screening Tests
+ *
+ * Covers:
+ *   Unit  — mocked provider responses (match, no-match, error)
+ *   Chaos — simulated provider timeout and 5xx
+ *   Integration — real Chainalysis / OpenSanctions call (gated by CI secrets)
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  createSanctionsScreener,
+  SanctionsScreener,
+  SanctionsMatch,
+} from '../../services/regulatory/sanctions';
+import {
+  createChainalysisProvider,
+  ChainalysisProvider,
+} from '../../services/regulatory/providers/chainalysis';
+import {
+  createOpenSanctionsProvider,
+  OpenSanctionsProvider,
+} from '../../services/regulatory/providers/opensanctions';
+import {
+  createListDownloader,
+  ListDownloader,
+} from '../../services/regulatory/providers/list-downloader';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const OFAC_MATCH: SanctionsMatch = {
+  list: 'ofac_sdn',
+  entityName: 'Sanctioned Corp',
+  entityType: 'entity',
+  matchScore: 100,
+  sanctionedSince: new Date('2020-01-01'),
+  programs: ['CYBER2'],
+  aliases: ['Bad Corp', 'Danger LLC'],
+};
+
+const EU_MATCH: SanctionsMatch = {
+  list: 'eu_consolidated',
+  entityName: 'EU Blocked Entity',
+  entityType: 'individual',
+  matchScore: 95,
+  sanctionedSince: new Date('2021-06-01'),
+  programs: ['EU_SANCTIONS'],
+  aliases: [],
+};
+
+// ============================================================================
+// Unit Tests — Internal Provider
+// ============================================================================
+
+describe('SanctionsScreener (internal provider)', () => {
+  let screener: SanctionsScreener;
+
+  beforeEach(() => {
+    screener = createSanctionsScreener({ provider: 'internal', matchThreshold: 85 });
+  });
+
+  it('returns no match for a clean address', async () => {
+    const result = await screener.screenAddress('EQC_clean_address');
+    expect(result.screened).toBe(true);
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(0);
+    expect(result.provider).toBe('internal');
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('returns match for a sanctioned address', async () => {
+    screener.addSanctionedAddress('EQC_sanctioned', [OFAC_MATCH]);
+
+    const result = await screener.screenAddress('EQC_sanctioned');
+    expect(result.isMatch).toBe(true);
+    expect(result.riskScore).toBe(100);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].list).toBe('ofac_sdn');
+  });
+
+  it('caches results and reuses cached entry', async () => {
+    screener.addSanctionedAddress('EQC_cached', [OFAC_MATCH]);
+
+    const first = await screener.screenAddress('EQC_cached');
+    const second = await screener.screenAddress('EQC_cached');
+
+    expect(second.cachedAt.getTime()).toBe(first.cachedAt.getTime());
+    expect(second.isMatch).toBe(true);
+  });
+
+  it('invalidates cache after addSanctionedAddress', async () => {
+    const firstResult = await screener.screenAddress('EQC_newaddr');
+    expect(firstResult.isMatch).toBe(false);
+
+    screener.addSanctionedAddress('EQC_newaddr', [OFAC_MATCH]);
+    const secondResult = await screener.screenAddress('EQC_newaddr');
+    expect(secondResult.isMatch).toBe(true);
+    expect(secondResult.cachedAt.getTime()).toBeGreaterThanOrEqual(firstResult.cachedAt.getTime());
+  });
+
+  it('respects matchThreshold — low-score hit is not a match', async () => {
+    const lowScore: SanctionsMatch = { ...OFAC_MATCH, matchScore: 50 };
+    screener.addSanctionedAddress('EQC_low_score', [lowScore]);
+
+    const result = await screener.screenAddress('EQC_low_score');
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(50);
+  });
+
+  it('handles multiple lists for the same address', async () => {
+    screener.addSanctionedAddress('EQC_multi', [OFAC_MATCH, EU_MATCH]);
+
+    const result = await screener.screenAddress('EQC_multi');
+    expect(result.isMatch).toBe(true);
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches.map((m) => m.list)).toContain('ofac_sdn');
+    expect(result.matches.map((m) => m.list)).toContain('eu_consolidated');
+  });
+
+  it('removes sanctioned address correctly', async () => {
+    screener.addSanctionedAddress('EQC_to_remove', [OFAC_MATCH]);
+    expect((await screener.screenAddress('EQC_to_remove')).isMatch).toBe(true);
+
+    screener.removeSanctionedAddress('EQC_to_remove');
+    const afterRemoval = await screener.screenAddress('EQC_to_remove');
+    expect(afterRemoval.isMatch).toBe(false);
+  });
+
+  it('screenEntity finds entity by name', async () => {
+    screener.addSanctionedAddress('EQC_entity_addr', [OFAC_MATCH]);
+
+    const result = await screener.screenEntity('Sanctioned Corp');
+    expect(result.screened).toBe(true);
+    expect(result.isMatch).toBe(true);
+    expect(result.provider).toBe('internal');
+  });
+
+  it('screenEntity finds entity by alias', async () => {
+    screener.addSanctionedAddress('EQC_alias_addr', [OFAC_MATCH]);
+
+    const result = await screener.screenEntity('Bad Corp');
+    expect(result.isMatch).toBe(true);
+  });
+
+  it('screenEntity returns no match for unknown entity', async () => {
+    const result = await screener.screenEntity('Totally Legitimate Business Inc');
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(0);
+  });
+
+  it('loadSanctionsList replaces entries for a given list', async () => {
+    screener.addSanctionedAddress('EQC_old', [OFAC_MATCH]);
+
+    screener.loadSanctionsList('ofac_sdn', [
+      { address: 'EQC_new', match: OFAC_MATCH },
+    ]);
+
+    const oldResult = await screener.screenAddress('EQC_old');
+    const newResult = await screener.screenAddress('EQC_new');
+    expect(oldResult.isMatch).toBe(false);
+    expect(newResult.isMatch).toBe(true);
+  });
+
+  it('isSanctionedAddress is a fast synchronous check', () => {
+    screener.addSanctionedAddress('EQC_sync', [OFAC_MATCH]);
+    expect(screener.isSanctionedAddress('EQC_sync')).toBe(true);
+    expect(screener.isSanctionedAddress('EQC_unknown')).toBe(false);
+  });
+
+  it('emits aml.transaction_blocked event on match', async () => {
+    const events: any[] = [];
+    screener.onEvent((e) => events.push(e));
+    screener.addSanctionedAddress('EQC_event', [OFAC_MATCH]);
+
+    await screener.screenAddress('EQC_event');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('aml.transaction_blocked');
+    expect(events[0].payload.address).toBe('EQC_event');
+  });
+
+  it('does not emit event on no-match', async () => {
+    const events: any[] = [];
+    screener.onEvent((e) => events.push(e));
+
+    await screener.screenAddress('EQC_clean');
+    expect(events).toHaveLength(0);
+  });
+
+  it('reports metrics correctly', async () => {
+    screener.addSanctionedAddress('EQC_m1', [OFAC_MATCH]);
+    await screener.screenAddress('EQC_m1');
+    await screener.screenAddress('EQC_m2');
+
+    const metrics = screener.getMetrics();
+    expect(metrics.totalScreenings).toBe(2);
+    expect(metrics.sanctionedAddressCount).toBe(1);
+    expect(metrics.checkTotal['internal:match']).toBe(1);
+    expect(metrics.checkTotal['internal:no_match']).toBe(1);
+  });
+
+  it('caches per listVersion — new version bypasses cache', async () => {
+    screener.addSanctionedAddress('EQC_v', [OFAC_MATCH]);
+    const r1 = await screener.screenAddress('EQC_v');
+    expect(r1.listVersion).toBe('default');
+
+    screener.setListVersion('2024-01-01');
+    const r2 = await screener.screenAddress('EQC_v');
+    expect(r2.listVersion).toBe('2024-01-01');
+    // r2 is fetched fresh (not from r1 cache) because version changed
+    expect(r2.cachedAt.getTime()).toBeGreaterThanOrEqual(r1.cachedAt.getTime());
+  });
+});
+
+// ============================================================================
+// Unit Tests — Chainalysis Provider (mocked fetch)
+// ============================================================================
+
+describe('SanctionsScreener with Chainalysis provider (mocked)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns match when Chainalysis reports sanctioned address', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          address: 'EQC_sanctioned',
+          risk: 'severe',
+          identifications: [
+            { category: 'sanctions', name: 'Evil Corp' },
+          ],
+          cluster: { name: 'Evil Cluster', category: 'sanctions' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+    });
+
+    const result = await screener.screenAddress('EQC_sanctioned');
+    expect(result.isMatch).toBe(true);
+    expect(result.provider).toBe('chainalysis');
+    expect(result.riskScore).toBe(100);
+    expect(result.providerError).toBeUndefined();
+  });
+
+  it('returns no-match for clean address from Chainalysis', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          address: 'EQC_clean',
+          risk: 'low',
+          identifications: [],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+    });
+
+    const result = await screener.screenAddress('EQC_clean');
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(20);
+    expect(result.provider).toBe('chainalysis');
+  });
+
+  it('returns no-match when Chainalysis returns 404 (unknown address)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Not Found', { status: 404 })
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+    });
+
+    const result = await screener.screenAddress('EQC_unknown');
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(0);
+  });
+
+  it('fail-closed: blocks on Chainalysis network error when failClosed=true', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: true,
+    });
+
+    const events: any[] = [];
+    screener.onEvent((e) => events.push(e));
+
+    const result = await screener.screenAddress('EQC_failclosed');
+    expect(result.isMatch).toBe(true);
+    expect(result.providerError).toBe(true);
+    expect(result.providerErrorMessage).toContain('ECONNREFUSED');
+    expect(result.riskScore).toBe(100);
+    expect(events.some((e) => e.type === 'aml.transaction_blocked')).toBe(true);
+  });
+
+  it('fail-open: falls back to internal list on Chainalysis error when failClosed=false', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('timeout'));
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: false,
+    });
+    screener.addSanctionedAddress('EQC_fallback', [OFAC_MATCH]);
+
+    const result = await screener.screenAddress('EQC_fallback');
+    expect(result.isMatch).toBe(true);
+    expect(result.provider).toBe('internal');
+    expect(result.providerError).toBeUndefined();
+  });
+
+  it('tracks chainalysis metrics for match/no-match/error', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ address: 'A', risk: 'severe', identifications: [{ category: 'sanctions', name: 'X' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ address: 'B', risk: 'low', identifications: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    fetchSpy.mockRejectedValueOnce(new Error('timeout'));
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: false,
+    });
+
+    await screener.screenAddress('A');
+    await screener.screenAddress('B');
+    await screener.screenAddress('C');
+
+    const metrics = screener.getMetrics();
+    expect(metrics.checkTotal['chainalysis:match']).toBe(1);
+    expect(metrics.checkTotal['chainalysis:no_match']).toBe(1);
+    expect(metrics.checkTotal['chainalysis:error']).toBe(1);
+    expect(metrics.providerCallCount).toBe(3);
+    expect(metrics.totalProviderDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ============================================================================
+// Unit Tests — OpenSanctions Provider (mocked fetch)
+// ============================================================================
+
+describe('SanctionsScreener with OpenSanctions provider (mocked)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockOpenSanctionsResponse(results: object[]): Response {
+    return new Response(
+      JSON.stringify({
+        responses: {
+          q: {
+            results,
+            total: { value: results.length },
+          },
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  it('returns entity match from OpenSanctions', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      mockOpenSanctionsResponse([
+        {
+          id: 'Q123',
+          caption: 'Evil Person',
+          score: 92,
+          datasets: ['us_ofac_sdn'],
+          properties: {
+            name: ['Evil Person'],
+            alias: ['E. Person'],
+            program: ['CYBER2'],
+            createdAt: ['2020-01-01'],
+          },
+        },
+      ])
+    );
+
+    const screener = createSanctionsScreener({
+      openSanctions: { apiKey: 'os-key' },
+    });
+
+    const result = await screener.screenEntity('Evil Person');
+    expect(result.isMatch).toBe(true);
+    expect(result.provider).toBe('opensanctions');
+    expect(result.matches[0].entityName).toBe('Evil Person');
+    expect(result.matches[0].list).toBe('ofac_sdn');
+  });
+
+  it('returns no match when OpenSanctions finds nothing', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      mockOpenSanctionsResponse([])
+    );
+
+    const screener = createSanctionsScreener({
+      openSanctions: { apiKey: 'os-key' },
+    });
+
+    const result = await screener.screenEntity('Legitimate Business Ltd');
+    expect(result.isMatch).toBe(false);
+    expect(result.riskScore).toBe(0);
+  });
+
+  it('fail-closed: blocks on OpenSanctions network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Connection refused'));
+
+    const screener = createSanctionsScreener({
+      openSanctions: { apiKey: 'os-key' },
+      failClosed: true,
+    });
+
+    const result = await screener.screenEntity('Some Entity');
+    expect(result.isMatch).toBe(true);
+    expect(result.providerError).toBe(true);
+    expect(result.providerErrorMessage).toContain('Connection refused');
+  });
+});
+
+// ============================================================================
+// Chaos Tests — Timeouts and 5xx
+// ============================================================================
+
+describe('SanctionsScreener chaos scenarios', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('handles Chainalysis 500 error as provider failure (fail-closed)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 })
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: true,
+    });
+
+    const result = await screener.screenAddress('EQC_chaos');
+    expect(result.isMatch).toBe(true);
+    expect(result.providerError).toBe(true);
+    expect(result.providerErrorMessage).toContain('500');
+  });
+
+  it('handles Chainalysis 503 error as provider failure (fail-closed)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Service Unavailable', { status: 503 })
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: true,
+    });
+
+    const result = await screener.screenAddress('EQC_503');
+    expect(result.isMatch).toBe(true);
+    expect(result.providerError).toBe(true);
+  });
+
+  it('handles simulated provider abort (timeout) gracefully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(() => {
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+      return Promise.reject(error);
+    });
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key', timeoutMs: 1 },
+      failClosed: true,
+    });
+
+    const result = await screener.screenAddress('EQC_timeout');
+    expect(result.isMatch).toBe(true);
+    expect(result.providerError).toBe(true);
+    expect(result.providerErrorMessage).toContain('aborted');
+  });
+
+  it('chaos: fail-open falls back to internal list on 5xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Gateway Timeout', { status: 504 })
+    );
+
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: 'test-key' },
+      failClosed: false,
+    });
+    screener.addSanctionedAddress('EQC_internal_hit', [OFAC_MATCH]);
+
+    const result = await screener.screenAddress('EQC_internal_hit');
+    expect(result.provider).toBe('internal');
+    expect(result.isMatch).toBe(true);
+  });
+});
+
+// ============================================================================
+// ListDownloader Unit Tests
+// ============================================================================
+
+describe('ListDownloader', () => {
+  let downloader: ListDownloader;
+
+  beforeEach(() => {
+    downloader = createListDownloader({ storagePath: '/tmp/test-sanctions-dl' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty entries for a list that has not been loaded', () => {
+    const entries = downloader.getEntries('ofac_sdn');
+    expect(entries).toHaveLength(0);
+  });
+
+  it('parses mocked OFAC CSV download', async () => {
+    const csvContent = [
+      '"Ent_num","SDN_Name","SDN_Type","Program","Title","Call_Sign","Vess_type","Tonnage","GRT","Vess_flag","Vess_owner","Remarks","Add_Num","Address","City/State/Province/Postal Code","Country","Add_Remarks"',
+      '"1234","Evil Corp","Entity","CYBER2","","","","","","","","Sanctioned 2020-01-01","","","",""',
+    ].join('\n');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(csvContent, { status: 200 })
+    );
+
+    const snapshot = await downloader.refreshList({
+      list: 'ofac_sdn',
+      url: 'https://example.com/sdn.csv',
+      format: 'ofac_csv',
+    } as any);
+
+    expect(snapshot.list).toBe('ofac_sdn');
+    expect(snapshot.entryCount).toBeGreaterThan(0);
+    expect(snapshot.checksum).toHaveLength(64); // SHA-256 hex
+  });
+
+  it('fires stale alert when list has not been updated within threshold', () => {
+    const alerts: any[] = [];
+    const dl = createListDownloader({
+      staleAlertThresholdMs: 0,
+      onStaleAlert: (list, lastSuccessAt) => alerts.push({ list, lastSuccessAt }),
+    });
+
+    dl.checkStaleness();
+    expect(alerts.length).toBeGreaterThan(0);
+    expect(alerts[0].lastSuccessAt).toBeNull();
+  });
+
+  it('toSanctionsEntries converts snapshot to screener-compatible format', async () => {
+    // Match the 17-column OFAC CSV format expected by parseOfacCsv
+    const cols = (n: number, val = '') => Array(n).fill(`"${val}"`).join(',');
+    const header = '"Ent_num","SDN_Name","SDN_Type","Program","Title","Call_Sign","Vess_type","Tonnage","GRT","Vess_flag","Vess_owner","Remarks","Add_Num","Address","City","Country","Add_Remarks"';
+    const row = `"1","Blocked Entity","Entity","SDGT","","","","","","","","2020-01-01","","","","",""`;
+    const csvContent = [header, row].join('\n');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(csvContent, { status: 200 })
+    );
+
+    await downloader.refreshList({
+      list: 'ofac_sdn',
+      url: 'https://example.com/sdn.csv',
+      format: 'ofac_csv',
+    } as any);
+
+    const entries = downloader.toSanctionsEntries('ofac_sdn');
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[0].match.list).toBe('ofac_sdn');
+    expect(entries[0].match.matchScore).toBe(100);
+  });
+
+  it('refreshAll returns results for each list', async () => {
+    // Mock 4 successful fetches
+    const mockFetch = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('mock-content', { status: 200 }));
+
+    const results = await downloader.refreshAll();
+    expect(results).toHaveLength(4);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('refreshAll reports error for failed downloads', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Network failure'));
+
+    const results = await downloader.refreshAll();
+    expect(results.every((r) => !r.success)).toBe(true);
+    expect(results[0].error).toContain('Network failure');
+  });
+});
+
+// ============================================================================
+// ChainalysisProvider Unit Tests
+// ============================================================================
+
+describe('ChainalysisProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps severe risk to score 100', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ address: 'A', risk: 'severe', identifications: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const provider = createChainalysisProvider({ apiKey: 'key' });
+    const result = await provider.screenAddress('A');
+    expect(result.riskScore).toBe(100);
+  });
+
+  it('throws on non-2xx non-404 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Bad Request', { status: 400 })
+    );
+
+    const provider = createChainalysisProvider({ apiKey: 'key' });
+    await expect(provider.screenAddress('A')).rejects.toThrow('HTTP 400');
+  });
+
+  it('throws on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('ENOTFOUND'));
+
+    const provider = createChainalysisProvider({ apiKey: 'key' });
+    await expect(provider.screenAddress('A')).rejects.toThrow('Chainalysis provider unreachable');
+  });
+
+  it('toSanctionsMatches returns empty array for non-sanctioned result', async () => {
+    const provider = createChainalysisProvider({ apiKey: 'key' });
+    const matches = provider.toSanctionsMatches({
+      address: 'A',
+      identifications: [{ category: 'exchange', name: 'Binance' }],
+      riskScore: 5,
+      sanctioned: false,
+    });
+    expect(matches).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// OpenSanctionsProvider Unit Tests
+// ============================================================================
+
+describe('OpenSanctionsProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('filters results below minScore', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          responses: {
+            q: {
+              results: [
+                { id: 'X', caption: 'Low Score Entity', score: 50, datasets: ['us_ofac_sdn'], properties: {} },
+              ],
+              total: { value: 1 },
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const provider = createOpenSanctionsProvider({ apiKey: 'key', minScore: 80 });
+    const result = await provider.screenEntity('Low Score Entity');
+    expect(result.matches).toHaveLength(0);
+    expect(result.hasHit).toBe(false);
+  });
+
+  it('throws on OpenSanctions API error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Unauthorized', { status: 401 })
+    );
+
+    const provider = createOpenSanctionsProvider({ apiKey: 'bad-key' });
+    await expect(provider.screenEntity('Test')).rejects.toThrow('HTTP 401');
+  });
+});
+
+// ============================================================================
+// Integration Tests — gated by CI secrets
+// ============================================================================
+
+const CHAINALYSIS_API_KEY = process.env['CHAINALYSIS_API_KEY'];
+const OPENSANCTIONS_API_KEY = process.env['OPENSANCTIONS_API_KEY'];
+
+describe.skipIf(!CHAINALYSIS_API_KEY)('Chainalysis live integration', () => {
+  it('screens a known-clean TON address', async () => {
+    const screener = createSanctionsScreener({
+      provider: 'chainalysis',
+      chainalysis: { apiKey: CHAINALYSIS_API_KEY! },
+      failClosed: true,
+    });
+
+    // Use a well-known TON foundation address — should not be sanctioned
+    const result = await screener.screenAddress('EQC62GUBmmfFHmvVEFPFN0i5GIbkIhSPnujBNS5q-0U6GC7a');
+    expect(result.screened).toBe(true);
+    expect(result.provider).toBe('chainalysis');
+    expect(result.providerError).toBeUndefined();
+  }, 30_000);
+});
+
+describe.skipIf(!OPENSANCTIONS_API_KEY)('OpenSanctions live integration', () => {
+  it('screens a known-sanctioned entity name', async () => {
+    const provider = createOpenSanctionsProvider({ apiKey: OPENSANCTIONS_API_KEY! });
+    const result = await provider.screenEntity('Viktor Bout');
+    // Viktor Bout is a well-known sanctioned individual
+    expect(result.hasHit).toBe(true);
+    expect(result.matches.length).toBeGreaterThan(0);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Resolves #341 — replaces the stub `SanctionsScreener` with real provider integrations so AML decisions are no longer cosmetic.

- **Chainalysis KYT** (`services/regulatory/providers/chainalysis.ts`): live on-chain address screening via the KYT v2 API. Fails closed (blocks trade) when unreachable.
- **OpenSanctions** (`services/regulatory/providers/opensanctions.ts`): entity/name screening against OFAC SDN, EU Consolidated, UN Security Council, UK HMT using the `/match/sanctions/` endpoint.
- **ListDownloader** (`services/regulatory/providers/list-downloader.ts`): scheduled downloader for the four official list files. Stores versioned, SHA-256-checksummed snapshots on disk; fires an alert when a list is stale for >48h.
- **Updated `sanctions.ts`**: wires providers into `SanctionsScreener` with fail-closed policy, per-`(address, listVersion)` cache keying, metrics (`sanctions_check_total{provider,result}`, `sanctions_check_duration_seconds`), and structured `aml.transaction_blocked` audit events on every positive hit.
- **41 tests** covering match/no-match/error for both providers, timeout/5xx chaos scenarios, list parser, and live integration tests gated by `CHAINALYSIS_API_KEY` / `OPENSANCTIONS_API_KEY` secrets.
- Updated `docs/regulatory-compliance.md`: provider selection, cost estimates, data flow, fail-closed policy.
- Updated `.env.example`: `CHAINALYSIS_API_KEY`, `OPENSANCTIONS_API_KEY`.

## Provider selection

| Need | Provider |
|------|----------|
| On-chain crypto address | Chainalysis KYT (primary) |
| Entity/name list screening | OpenSanctions (primary) |

## Fail-closed policy

When `failClosed: true` (default): provider unreachability → `isMatch: true`, `providerError: true` → trade blocked. The `aml.transaction_blocked` event is emitted with `reason: 'provider_error'`. Only set `failClosed: false` for dev/testnet.

## Data flow

```
[Chainalysis KYT]  ──┐
                      ├──► SanctionsScreener ──► result (isMatch / riskScore)
[OpenSanctions]    ──┤         │
                      │         └──► aml.transaction_blocked event on hit
[ListDownloader]   ──┘              └──► structured audit log entry
  (OFAC/EU/UN/UK)
```

## Test plan

- [x] `npx vitest run tests/regulatory/` — 136 passed, 2 skipped (live integration, gated by API keys)
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [ ] Nightly CI job: set `CHAINALYSIS_API_KEY` and `OPENSANCTIONS_API_KEY` secrets to run live integration tests